### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python lint and tests
 
 on: [push, pull_request]
 
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']

--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -12,14 +12,6 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade uv tox tox-uv
-      - name: Test with tox
-        run: tox -e py
-      - name: Run linters
-        run: tox -e lint
-
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The main workflow now has an appropriate name and the fail-fast strategy is disabled, allowing linting and testing steps to continue on each python version.

The tagged release workflow do not run linters and tets anymore.