### PR TITLE
Replace deprecated token query param by X-Consul-Token header 

### DIFF
--- a/consul/api/acl/policy.py
+++ b/consul/api/acl/policy.py
@@ -15,10 +15,9 @@ class Policy:
         Requires a token with acl:read capability. ACLPermissionDenied raised otherwise
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
-        return self.agent.http.get(CB.json(), "/v1/acl/policies", params=params)
+
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), "/v1/acl/policies", params=params, headers=headers)
 
     def read(self, uuid, token=None):
         """
@@ -28,10 +27,8 @@ class Policy:
         :return: selected Polic information
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
-        return self.agent.http.get(CB.json(), f"/v1/acl/policy/{uuid}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/acl/policy/{uuid}", params=params, headers=headers)
 
     def create(self, name, token=None, description=None, rules=None):
         """
@@ -44,17 +41,16 @@ class Policy:
         :return: The cloned token information
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         json_data = {"name": name}
         if rules:
             json_data["rules"] = json.dumps(rules)
         if description:
             json_data["Description"] = description
+        headers = self.agent.prepare_headers(token)
         return self.agent.http.put(
             CB.json(),
             "/v1/acl/policy",
             params=params,
+            headers=headers,
             data=json.dumps(json_data),
         )

--- a/consul/api/acl/token.py
+++ b/consul/api/acl/token.py
@@ -15,10 +15,8 @@ class Token:
         Requires a token with acl:read capability. ACLPermissionDenied raised otherwise
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
-        return self.agent.http.get(CB.json(), "/v1/acl/tokens", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), "/v1/acl/tokens", params=params, headers=headers)
 
     def read(self, accessor_id, token=None):
         """
@@ -28,10 +26,8 @@ class Token:
         :return: selected token information
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
-        return self.agent.http.get(CB.json(), f"/v1/acl/token/{accessor_id}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/acl/token/{accessor_id}", params=params, headers=headers)
 
     def delete(self, accessor_id, token=None):
         """
@@ -41,10 +37,8 @@ class Token:
         :return: True if the token was deleted
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
-        return self.agent.http.delete(CB.bool(), f"/v1/acl/token/{accessor_id}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.delete(CB.bool(), f"/v1/acl/token/{accessor_id}", params=params, headers=headers)
 
     def clone(self, accessor_id, token=None, description=""):
         """
@@ -55,15 +49,14 @@ class Token:
         :return: The cloned token information
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
 
         json_data = {"Description": description}
+        headers = self.agent.prepare_headers(token)
         return self.agent.http.put(
             CB.json(),
             f"/v1/acl/token/{accessor_id}/clone",
             params=params,
+            headers=headers,
             data=json.dumps(json_data),
         )
 
@@ -79,9 +72,6 @@ class Token:
         :return: The cloned token information
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
 
         json_data = {}
         if accessor_id:
@@ -93,10 +83,12 @@ class Token:
         if policies_id:
             json_data["Policies"] = [{"ID": policy} for policy in policies_id]
 
+        headers = self.agent.prepare_headers(token)
         return self.agent.http.put(
             CB.json(),
             "/v1/acl/token",
             params=params,
+            headers=headers,
             data=json.dumps(json_data),
         )
 
@@ -111,18 +103,17 @@ class Token:
         :return: The updated token information
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
 
         json_data = {"AccessorID": accessor_id}
         if secret_id:
             json_data["SecretID"] = secret_id
         if description:
             json_data["Description"] = description
+        headers = self.agent.prepare_headers(token)
         return self.agent.http.put(
             CB.json(),
             f"/v1/acl/token/{accessor_id}",
             params=params,
+            headers=headers,
             data=json.dumps(json_data),
         )

--- a/consul/api/agent.py
+++ b/consul/api/agent.py
@@ -89,11 +89,9 @@ class Agent:
         params.append(("enable", enable))
         if reason:
             params.append(("reason", reason))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
 
-        return self.agent.http.put(CB.bool(), "/v1/agent/maintenance", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.bool(), "/v1/agent/maintenance", params=params, headers=headers)
 
     def join(self, address, wan=False, token=None):
         """
@@ -111,11 +109,8 @@ class Agent:
 
         if wan:
             params.append(("wan", 1))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
-
-        return self.agent.http.put(CB.bool(), f"/v1/agent/join/{address}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.bool(), f"/v1/agent/join/{address}", params=params, headers=headers)
 
     def force_leave(self, node, token=None):
         """
@@ -131,11 +126,8 @@ class Agent:
 
         params = []
 
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
-
-        return self.agent.http.put(CB.bool(), f"/v1/agent/force-leave/{node}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.bool(), f"/v1/agent/force-leave/{node}", params=params, headers=headers)
 
     class Service:
         def __init__(self, agent):
@@ -231,11 +223,10 @@ class Agent:
                 )
 
             params = []
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
-
-            return self.agent.http.put(CB.bool(), "/v1/agent/service/register", params=params, data=json.dumps(payload))
+            headers = self.agent.prepare_headers(token)
+            return self.agent.http.put(
+                CB.bool(), "/v1/agent/service/register", params=params, headers=headers, data=json.dumps(payload)
+            )
 
         def deregister(self, service_id, token=None):
             """
@@ -244,11 +235,11 @@ class Agent:
             there is an associated check, that is also deregistered.
             """
             params = []
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
+            headers = self.agent.prepare_headers(token)
 
-            return self.agent.http.put(CB.bool(), f"/v1/agent/service/deregister/{service_id}", params=params)
+            return self.agent.http.put(
+                CB.bool(), f"/v1/agent/service/deregister/{service_id}", params=params, headers=headers
+            )
 
         def maintenance(self, service_id, enable, reason=None, token=None):
             """
@@ -271,11 +262,11 @@ class Agent:
             if reason:
                 params.append(("reason", reason))
 
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
+            headers = self.agent.prepare_headers(token)
 
-            return self.agent.http.put(CB.bool(), f"/v1/agent/service/maintenance/{service_id}", params=params)
+            return self.agent.http.put(
+                CB.bool(), f"/v1/agent/service/maintenance/{service_id}", params=params, headers=headers
+            )
 
     class Check:
         def __init__(self, agent):
@@ -344,22 +335,21 @@ class Agent:
                 payload["serviceid"] = service_id
 
             params = []
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
-
-            return self.agent.http.put(CB.bool(), "/v1/agent/check/register", params=params, data=json.dumps(payload))
+            headers = self.agent.prepare_headers(token)
+            return self.agent.http.put(
+                CB.bool(), "/v1/agent/check/register", params=params, headers=headers, data=json.dumps(payload)
+            )
 
         def deregister(self, check_id, token=None):
             """
             Remove a check from the local agent.
             """
             params = []
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
+            headers = self.agent.prepare_headers(token)
 
-            return self.agent.http.put(CB.bool(), f"/v1/agent/check/deregister/{check_id}", params=params)
+            return self.agent.http.put(
+                CB.bool(), f"/v1/agent/check/deregister/{check_id}", params=params, headers=headers
+            )
 
         def ttl_pass(self, check_id, notes=None, token=None):
             """
@@ -369,11 +359,9 @@ class Agent:
             params = []
             if notes:
                 params.append(("note", notes))
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
+            headers = self.agent.prepare_headers(token)
 
-            return self.agent.http.put(CB.bool(), f"/v1/agent/check/pass/{check_id}", params=params)
+            return self.agent.http.put(CB.bool(), f"/v1/agent/check/pass/{check_id}", params=params, headers=headers)
 
         def ttl_fail(self, check_id, notes=None, token=None):
             """
@@ -384,11 +372,9 @@ class Agent:
             params = []
             if notes:
                 params.append(("note", notes))
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
+            headers = self.agent.prepare_headers(token)
 
-            return self.agent.http.put(CB.bool(), f"/v1/agent/check/fail/{check_id}", params=params)
+            return self.agent.http.put(CB.bool(), f"/v1/agent/check/fail/{check_id}", params=params, headers=headers)
 
         def ttl_warn(self, check_id, notes=None, token=None):
             """
@@ -399,11 +385,9 @@ class Agent:
             params = []
             if notes:
                 params.append(("note", notes))
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
+            headers = self.agent.prepare_headers(token)
 
-            return self.agent.http.put(CB.bool(), f"/v1/agent/check/warn/{check_id}", params=params)
+            return self.agent.http.put(CB.bool(), f"/v1/agent/check/warn/{check_id}", params=params, headers=headers)
 
     class Connect:
         def __init__(self, agent):
@@ -429,12 +413,10 @@ class Agent:
             payload = {"Target": target, "ClientCertURI": client_cert_uri, "ClientCertSerial": client_cert_serial}
 
             params = []
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
+            headers = self.agent.prepare_headers(token)
 
             return self.agent.http.put(
-                CB.json(), "/v1/agent/connect/authorize", params=params, data=json.dumps(payload)
+                CB.json(), "/v1/agent/connect/authorize", params=params, headers=headers, data=json.dumps(payload)
             )
 
         class CA:
@@ -446,8 +428,8 @@ class Agent:
 
             def leaf(self, service, token=None):
                 params = []
-                token = token or self.agent.token
-                if token:
-                    params.append(("token", token))
+                headers = self.agent.prepare_headers(token)
 
-                return self.agent.http.get(CB.json(), f"/v1/agent/connect/ca/leaf/{service}", params=params)
+                return self.agent.http.get(
+                    CB.json(), f"/v1/agent/connect/ca/leaf/{service}", params=params, headers=headers
+                )

--- a/consul/api/catalog.py
+++ b/consul/api/catalog.py
@@ -82,7 +82,11 @@ class Catalog:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
-        return self.agent.http.put(CB.bool(), "/v1/catalog/register", data=json.dumps(data), params=params)
+
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(
+            CB.bool(), "/v1/catalog/register", data=json.dumps(data), params=params, headers=headers
+        )
 
     def deregister(self, node, service_id=None, check_id=None, dc=None, token=None):
         """
@@ -112,7 +116,8 @@ class Catalog:
         token = token or self.agent.token
         if token:
             data["WriteRequest"] = {"Token": token}
-        return self.agent.http.put(CB.bool(), "/v1/catalog/deregister", data=json.dumps(data))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.bool(), "/v1/catalog/deregister", headers=headers, data=json.dumps(data))
 
     def datacenters(self):
         """
@@ -168,16 +173,15 @@ class Catalog:
                 params.append(("wait", wait))
         if near:
             params.append(("near", near))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
+
         consistency = consistency or self.agent.consistency
         if consistency in ("consistent", "stale"):
             params.append((consistency, "1"))
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
-        return self.agent.http.get(CB.json(index=True), "/v1/catalog/nodes", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), "/v1/catalog/nodes", params=params, headers=headers)
 
     def services(self, index=None, wait=None, consistency=None, dc=None, token=None, node_meta=None):
         """
@@ -223,16 +227,14 @@ class Catalog:
             params.append(("index", index))
             if wait:
                 params.append(("wait", wait))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         consistency = consistency or self.agent.consistency
         if consistency in ("consistent", "stale"):
             params.append((consistency, "1"))
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
-        return self.agent.http.get(CB.json(index=True), "/v1/catalog/services", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), "/v1/catalog/services", params=params, headers=headers)
 
     def node(self, node, index=None, wait=None, consistency=None, dc=None, token=None):
         """
@@ -288,13 +290,11 @@ class Catalog:
             params.append(("index", index))
             if wait:
                 params.append(("wait", wait))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         consistency = consistency or self.agent.consistency
         if consistency in ("consistent", "stale"):
             params.append((consistency, "1"))
-        return self.agent.http.get(CB.json(index=True), f"/v1/catalog/node/{node}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), f"/v1/catalog/node/{node}", params=params, headers=headers)
 
     def _service(
         self,
@@ -320,16 +320,14 @@ class Catalog:
                 params.append(("wait", wait))
         if near:
             params.append(("near", near))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         consistency = consistency or self.agent.consistency
         if consistency in ("consistent", "stale"):
             params.append((consistency, "1"))
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
-        return self.agent.http.get(CB.json(index=True), internal_uri, params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), internal_uri, params=params, headers=headers)
 
     def service(self, service, **kwargs):
         """

--- a/consul/api/connect.py
+++ b/consul/api/connect.py
@@ -13,16 +13,12 @@ class Connect:
         def roots(self, pem=False, token=None):
             params = []
             params.append(("pem", int(pem)))
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
 
-            return self.agent.http.get(CB.json(), "/v1/connect/ca/roots", params=params)
+            headers = self.agent.prepare_headers(token)
+            return self.agent.http.get(CB.json(), "/v1/connect/ca/roots", params=params, headers=headers)
 
         def configuration(self, token=None):
             params = []
-            token = token or self.agent.token
-            if token:
-                params.append(("token", token))
 
-            return self.agent.http.get(CB.json(), "/v1/connect/ca/configuration", params=params)
+            headers = self.agent.prepare_headers(token)
+            return self.agent.http.get(CB.json(), "/v1/connect/ca/configuration", params=params, headers=headers)

--- a/consul/api/event.py
+++ b/consul/api/event.py
@@ -50,11 +50,9 @@ class Event:
             params.append(("service", service))
         if tag is not None:
             params.append(("tag", tag))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
 
-        return self.agent.http.put(CB.json(), f"/v1/event/fire/{name}", params=params, data=body)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.json(), f"/v1/event/fire/{name}", params=params, headers=headers, data=body)
 
     def list(self, name=None, index=None, wait=None):
         """

--- a/consul/api/health.py
+++ b/consul/api/health.py
@@ -35,13 +35,11 @@ class Health:
             params.append(("dc", dc))
         if near:
             params.append(("near", near))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
-        return self.agent.http.get(CB.json(index=True), internal_uri, params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), internal_uri, params=params, headers=headers)
 
     def service(self, service, **kwargs):
         """
@@ -122,13 +120,11 @@ class Health:
             params.append(("dc", dc))
         if near:
             params.append(("near", near))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
-        return self.agent.http.get(CB.json(index=True), f"/v1/health/checks/{service}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), f"/v1/health/checks/{service}", params=params, headers=headers)
 
     def state(self, name, index=None, wait=None, dc=None, near=None, token=None, node_meta=None):
         """
@@ -171,13 +167,11 @@ class Health:
             params.append(("dc", dc))
         if near:
             params.append(("near", near))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
-        return self.agent.http.get(CB.json(index=True), f"/v1/health/state/{name}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), f"/v1/health/state/{name}", params=params, headers=headers)
 
     def node(self, node, index=None, wait=None, dc=None, token=None):
         """
@@ -205,8 +199,6 @@ class Health:
         dc = dc or self.agent.dc
         if dc:
             params.append(("dc", dc))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
 
-        return self.agent.http.get(CB.json(index=True), f"/v1/health/node/{node}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(index=True), f"/v1/health/node/{node}", params=params, headers=headers)

--- a/consul/api/kv.py
+++ b/consul/api/kv.py
@@ -71,9 +71,6 @@ class KV:
                 params.append(("wait", wait))
         if recurse:
             params.append(("recurse", "1"))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         dc = dc or self.agent.dc
         if dc:
             params.append(("dc", dc))
@@ -95,8 +92,10 @@ class KV:
         http_kwargs = {}
         if connections_timeout:
             http_kwargs["connections_timeout"] = connections_timeout
+
+        headers = self.agent.prepare_headers(token)
         return self.agent.http.get(
-            CB.json(index=True, decode=decode, one=one), f"/v1/kv/{key}", params=params, **http_kwargs
+            CB.json(index=True, decode=decode, one=one), f"/v1/kv/{key}", params=params, headers=headers, **http_kwargs
         )
 
     def put(
@@ -156,16 +155,16 @@ class KV:
             params.append(("acquire", acquire))
         if release:
             params.append(("release", release))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         dc = dc or self.agent.dc
         if dc:
             params.append(("dc", dc))
         http_kwargs = {}
         if connections_timeout:
             http_kwargs["connections_timeout"] = connections_timeout
-        return self.agent.http.put(CB.json(), f"/v1/kv/{key}", params=params, data=value, **http_kwargs)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(
+            CB.json(), f"/v1/kv/{key}", params=params, headers=headers, data=value, **http_kwargs
+        )
 
     def delete(self, key, recurse=None, cas=None, token=None, dc=None, connections_timeout=None):
         """
@@ -193,13 +192,11 @@ class KV:
             params.append(("recurse", "1"))
         if cas is not None:
             params.append(("cas", cas))
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         dc = dc or self.agent.dc
         if dc:
             params.append(("dc", dc))
         http_kwargs = {}
         if connections_timeout:
             http_kwargs["connections_timeout"] = connections_timeout
-        return self.agent.http.delete(CB.json(), f"/v1/kv/{key}", params=params, **http_kwargs)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.delete(CB.json(), f"/v1/kv/{key}", params=params, headers=headers, **http_kwargs)

--- a/consul/api/query.py
+++ b/consul/api/query.py
@@ -19,13 +19,11 @@ class Query:
         *token* is an optional `ACL token`_ to apply to this request.
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if dc:
             params.append(("dc", dc))
 
-        return self.agent.http.get(CB.json(), "/v1/query", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), "/v1/query", params=params, headers=headers)
 
     def _query_data(
         self,
@@ -165,12 +163,10 @@ class Query:
         default the datacenter of the host is used.
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if dc:
             params.append(("dc", dc))
-        return self.agent.http.get(CB.json(), f"/v1/query/{query_id}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/query/{query_id}", params=params, headers=headers)
 
     def delete(self, query_id, token=None, dc=None):
         """
@@ -184,12 +180,10 @@ class Query:
         default the datacenter of the host is used.
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if dc:
             params.append(("dc", dc))
-        return self.agent.http.delete(CB.bool(), f"/v1/query/{query_id}", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.delete(CB.bool(), f"/v1/query/{query_id}", params=params, headers=headers)
 
     def execute(self, query, token=None, dc=None, near=None, limit=None):
         """
@@ -209,16 +203,14 @@ class Query:
         of nodes. This is applied after any sorting or shuffling.
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if dc:
             params.append(("dc", dc))
         if near:
             params.append(("near", near))
         if limit:
             params.append(("limit", limit))
-        return self.agent.http.get(CB.json(), f"/v1/query/{query}/execute", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/query/{query}/execute", params=params, headers=headers)
 
     def explain(self, query, token=None, dc=None):
         """
@@ -232,9 +224,7 @@ class Query:
         default the datacenter of the host is used.
         """
         params = []
-        token = token or self.agent.token
-        if token:
-            params.append(("token", token))
         if dc:
             params.append(("dc", dc))
-        return self.agent.http.get(CB.json(), f"/v1/query/{query}/explain", params=params)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/query/{query}/explain", params=params, headers=headers)

--- a/consul/base.py
+++ b/consul/base.py
@@ -3,6 +3,7 @@ import collections
 import logging
 import os
 import urllib
+from typing import Dict, Optional
 
 from consul.api.acl import ACL
 from consul.api.agent import Agent
@@ -45,19 +46,19 @@ class HTTPClient(metaclass=abc.ABCMeta):
         return uri
 
     @abc.abstractmethod
-    def get(self, callback, path, params=None):
+    def get(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def put(self, callback, path, params=None, data=""):
+    def put(self, callback, path, params=None, data="", headers: Optional[Dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def delete(self, callback, path, params=None):
+    def delete(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def post(self, callback, path, params=None, data=""):
+    def post(self, callback, path, params=None, data="", headers: Optional[Dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -151,3 +152,9 @@ class Consul:
     @abc.abstractmethod
     def http_connect(self, host, port, scheme, verify=True, cert=None):
         pass
+
+    def prepare_headers(self, token: Optional[str] = None) -> Dict[str, str]:
+        headers = {}
+        if token or self.token:
+            headers["X-Consul-Token"] = token or self.token
+        return headers

--- a/consul/std.py
+++ b/consul/std.py
@@ -1,3 +1,5 @@
+from typing import Dict, Optional
+
 import requests
 
 from consul import base
@@ -14,21 +16,25 @@ class HTTPClient(base.HTTPClient):
         response.encoding = "utf-8"
         return base.Response(response.status_code, response.headers, response.text)
 
-    def get(self, callback, path, params=None):
+    def get(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
         uri = self.uri(path, params)
-        return callback(self.response(self.session.get(uri, verify=self.verify, cert=self.cert)))
+        return callback(self.response(self.session.get(uri, headers=headers, verify=self.verify, cert=self.cert)))
 
-    def put(self, callback, path, params=None, data=""):
+    def put(self, callback, path, params=None, data="", headers: Optional[Dict[str, str]] = None):
         uri = self.uri(path, params)
-        return callback(self.response(self.session.put(uri, data=data, verify=self.verify, cert=self.cert)))
+        return callback(
+            self.response(self.session.put(uri, headers=headers, data=data, verify=self.verify, cert=self.cert))
+        )
 
-    def delete(self, callback, path, params=None):
+    def delete(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
         uri = self.uri(path, params)
-        return callback(self.response(self.session.delete(uri, verify=self.verify, cert=self.cert)))
+        return callback(self.response(self.session.delete(uri, headers=headers, verify=self.verify, cert=self.cert)))
 
-    def post(self, callback, path, params=None, data=""):
+    def post(self, callback, path, params=None, data="", headers: Optional[Dict[str, str]] = None):
         uri = self.uri(path, params)
-        return callback(self.response(self.session.post(uri, data=data, verify=self.verify, cert=self.cert)))
+        return callback(
+            self.response(self.session.post(uri, headers=headers, data=data, verify=self.verify, cert=self.cert))
+        )
 
     def close(self):
         pass

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,21 +6,21 @@ import pytest
 import consul
 import consul.check
 
-Request = collections.namedtuple("Request", ["method", "path", "params", "data"])
+Request = collections.namedtuple("Request", ["method", "path", "params", "headers", "data"])
 
 
 class HTTPClient:
     def __init__(self, host=None, port=None, scheme=None, verify=True, cert=None):
         pass
 
-    def get(self, callback, path, params=None):  # pylint: disable=unused-argument
-        return Request("get", path, params, None)
+    def get(self, callback, path, params=None, headers=None):  # pylint: disable=unused-argument
+        return Request("get", path, params, headers, None)
 
-    def put(self, callback, path, params=None, data=""):  # pylint: disable=unused-argument
-        return Request("put", path, params, data)
+    def put(self, callback, path, params=None, headers=None, data=""):  # pylint: disable=unused-argument
+        return Request("put", path, params, headers, data)
 
-    def delete(self, callback, path, params=None):  # pylint: disable=unused-argument
-        return Request("delete", path, params, None)
+    def delete(self, callback, path, params=None, headers=None):  # pylint: disable=unused-argument
+        return Request("delete", path, params, headers, None)
 
 
 class Consul(consul.base.Consul):


### PR DESCRIPTION
Fix a pretty rare docker start flakyness by retrying a few times if required.

?token=<token> query param is deprecated. It should have been removed in consul 1.17.
While it's still properly handled as of 1.18 at least, we should now use X-Consul-Token header

This overrides a previous PR https://github.com/criteo/py-consul/pull/51