### PR TITLE
Add support for honoring additional arguments in consul.Consul()

### DIFF
--- a/consul/base.py
+++ b/consul/base.py
@@ -79,10 +79,10 @@ class Consul:
         host: str | None = None,
         port: int | None = None,
         token: str | None = None,
-        scheme: str = "http",
+        scheme: str | None = None,
         consistency: str = "default",
         dc=None,
-        verify: bool = True,
+        verify: bool | None = None,
         cert=None,
     ) -> None:
         """
@@ -118,11 +118,19 @@ class Consul:
         if not port:
             port = 8500
 
-        use_ssl = os.getenv("CONSUL_HTTP_SSL")
-        if use_ssl is not None:
-            scheme = "https" if use_ssl == "true" else "http"
-        if os.getenv("CONSUL_HTTP_SSL_VERIFY") is not None:
-            verify = os.getenv("CONSUL_HTTP_SSL_VERIFY") == "true"
+        if scheme is None:
+            use_ssl = os.getenv("CONSUL_HTTP_SSL")
+            if use_ssl:
+                scheme = "https" if use_ssl.lower() == "true" else "http"
+            else:
+                scheme = "http"
+
+        if verify is None:
+            ssl_verify = os.getenv("CONSUL_HTTP_SSL_VERIFY")
+            if ssl_verify:
+                verify = ssl_verify.lower() == "true"
+            else:
+                verify = True
 
         self.http = self.http_connect(host, port, scheme, verify, cert)
         self.token = os.getenv("CONSUL_HTTP_TOKEN", token)

--- a/consul/base.py
+++ b/consul/base.py
@@ -76,8 +76,8 @@ class HTTPClient(metaclass=abc.ABCMeta):
 class Consul:
     def __init__(
         self,
-        host: str = "127.0.0.1",
-        port: int = 8500,
+        host: str | None = None,
+        port: int | None = None,
         token: str | None = None,
         scheme: str = "http",
         consistency: str = "default",
@@ -106,13 +106,18 @@ class Consul:
 
         # TODO: Status
 
-        if os.getenv("CONSUL_HTTP_ADDR"):
+        if os.getenv("CONSUL_HTTP_ADDR") and not (host or port):
             try:
                 host, port = os.getenv("CONSUL_HTTP_ADDR").split(":")  # type: ignore
             except ValueError as err:
                 raise ConsulException(
                     f"CONSUL_HTTP_ADDR ({os.getenv('CONSUL_HTTP_ADDR')}) invalid, does not match <host>:<port>"
                 ) from err
+        if not host:
+            host = "127.0.0.1"
+        if not port:
+            port = 8500
+
         use_ssl = os.getenv("CONSUL_HTTP_SSL")
         if use_ssl is not None:
             scheme = "https" if use_ssl == "true" else "http"

--- a/consul/base.py
+++ b/consul/base.py
@@ -120,17 +120,11 @@ class Consul:
 
         if scheme is None:
             use_ssl = os.getenv("CONSUL_HTTP_SSL")
-            if use_ssl:
-                scheme = "https" if use_ssl.lower() == "true" else "http"
-            else:
-                scheme = "http"
+            scheme = ("https" if use_ssl.lower() == "true" else "http") if use_ssl else "http"
 
         if verify is None:
             ssl_verify = os.getenv("CONSUL_HTTP_SSL_VERIFY")
-            if ssl_verify:
-                verify = ssl_verify.lower() == "true"
-            else:
-                verify = True
+            verify = ssl_verify.lower() == "true" if ssl_verify else True
 
         self.http = self.http_connect(host, port, scheme, verify, cert)
         self.token = os.getenv("CONSUL_HTTP_TOKEN", token)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,7 @@ class HTTPClient:
         self, host: Optional[str] = None, port: Optional[int] = None, scheme=None, verify: bool = True, cert=None
     ) -> None:
         self.host = host
-        self.port = port if port else None
+        self.port = int(port) if port else None
         self.scheme = scheme
         self.verify = verify
         self.cert = cert


### PR DESCRIPTION
Currently, the `host`, `port`, `verify`, and `scheme` arguments get ignored on initialization if an environment variable is set. This adds support for overriding the environment variables.