### PR TITLE
Improve robustness of JSON decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 1.5.4
+
+- **feature:**  Improve robustness of JSON decoding
+- **feature:**  Add support for honoring additional arguments in consul.Consul()
+
 ## 1.5.3
 
 - **feature:** add replace_existing_checks option to agent.service.register()

--- a/consul/__init__.py
+++ b/consul/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 from consul.check import Check
 from consul.exceptions import ACLDisabled, ACLPermissionDenied, ConsulException, NotFound, Timeout

--- a/consul/callback.py
+++ b/consul/callback.py
@@ -79,11 +79,8 @@ class CB:
                             item[decode] = base64.b64decode(item[decode])
                 if is_id:
                     data = data["ID"]
-                if one:
-                    if data == []:
-                        data = None
-                    if data is not None:
-                        data = data[0]
+                if one and isinstance(data, list):
+                    data = data[0] if data else None
                 if postprocess:
                     data = postprocess(data)
             if index:


### PR DESCRIPTION
If JSON decoding fails, if a field is missing, or if there are no fields, a ConsulException is returned.