### PR TITLE
Consul 1.20 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_language_version:
   python: python3.9
 default_install_hook_types: [pre-commit,pre-push]
-default_stages: [commit]
+default_stages: [pre-commit]
 exclude: ^docs/
 
 repos:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Status
 This project is maintained and actively developed by Criteo.
 We aim at converging towards a full compatibility with the official Consul API.
 
-We're currently supporting consul 1.13 up to 1.17. Due to quite a few changes 
+We're currently supporting consul 1.17 up to 1.20. Due to quite a few changes
 since our development started (see section "A bit of history"), some endpoints are 
 still partially handled.
 

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ from docker import DockerClient
 from docker.errors import APIError, NotFound
 from requests import RequestException
 
-CONSUL_VERSIONS = ["1.16.1", "1.17.3"]
+CONSUL_VERSIONS = ["1.17.3", "1.19.2", "1.20.2"]
 
 ConsulInstance = collections.namedtuple("ConsulInstance", ["container", "port", "version"])
 

--- a/consul/aio.py
+++ b/consul/aio.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 import aiohttp
 
@@ -24,7 +24,7 @@ class HTTPClient(base.HTTPClient):
         self._session = aiohttp.ClientSession(connector=connector, **session_kwargs)  # type: ignore
 
     async def _request(
-        self, callback, method, uri, headers: Optional[Dict[str, str]], data=None, connections_timeout=None
+        self, callback, method, uri, headers: Optional[dict[str, str]], data=None, connections_timeout=None
     ):
         session_kwargs = {}
         if connections_timeout:
@@ -37,7 +37,7 @@ class HTTPClient(base.HTTPClient):
         r = base.Response(resp.status, resp.headers, body)
         return callback(r)
 
-    def get(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None, connections_timeout=None):
+    def get(self, callback, path, params=None, headers: Optional[dict[str, str]] = None, connections_timeout=None):
         uri = self.uri(path, params)
         return self._request(callback, "GET", uri, headers=headers, connections_timeout=connections_timeout)
 
@@ -47,13 +47,13 @@ class HTTPClient(base.HTTPClient):
         path,
         params=None,
         data: str = "",
-        headers: Optional[Dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
         connections_timeout=None,
     ):
         uri = self.uri(path, params)
         return self._request(callback, "PUT", uri, headers=headers, data=data, connections_timeout=connections_timeout)
 
-    def delete(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None, connections_timeout=None):
+    def delete(self, callback, path, params=None, headers: Optional[dict[str, str]] = None, connections_timeout=None):
         uri = self.uri(path, params)
         return self._request(callback, "DELETE", uri, headers=headers, connections_timeout=connections_timeout)
 
@@ -63,7 +63,7 @@ class HTTPClient(base.HTTPClient):
         path,
         params=None,
         data: str = "",
-        headers: Optional[Dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
         connections_timeout=None,
     ):
         uri = self.uri(path, params)

--- a/consul/api/acl/token.py
+++ b/consul/api/acl/token.py
@@ -5,6 +5,9 @@ import typing
 
 from consul.callback import CB
 
+if typing.TYPE_CHECKING:
+    import builtins
+
 
 class Token:
     def __init__(self, agent) -> None:
@@ -63,7 +66,7 @@ class Token:
         token: str | None = None,
         accessor_id: str | None = None,
         secret_id: str | None = None,
-        policies_id: typing.List[str] | None = None,
+        policies_id: builtins.list[str] | None = None,
         description: str = "",
     ):
         """

--- a/consul/base.py
+++ b/consul/base.py
@@ -5,7 +5,7 @@ import collections
 import logging
 import os
 import urllib
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Optional
 
 from consul.api.acl import ACL
 from consul.api.agent import Agent
@@ -53,19 +53,19 @@ class HTTPClient(metaclass=abc.ABCMeta):
         return uri
 
     @abc.abstractmethod
-    def get(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
+    def get(self, callback, path, params=None, headers: Optional[dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def put(self, callback, path, params=None, data: str = "", headers: Optional[Dict[str, str]] = None):
+    def put(self, callback, path, params=None, data: str = "", headers: Optional[dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def delete(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
+    def delete(self, callback, path, params=None, headers: Optional[dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def post(self, callback, path, params=None, data: str = "", headers: Optional[Dict[str, str]] = None):
+    def post(self, callback, path, params=None, data: str = "", headers: Optional[dict[str, str]] = None):
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -158,12 +158,12 @@ class Consul:
         return self
 
     def __exit__(
-        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+        self, exc_type: Optional[type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
     ) -> None:
         self.http.close()
 
     async def __aexit__(
-        self, exc_type: Optional[Type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
+        self, exc_type: Optional[type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
     ) -> None:
         await self.http.close()
 
@@ -171,7 +171,7 @@ class Consul:
     def http_connect(self, host: str, port: int, scheme, verify: bool = True, cert=None):
         pass
 
-    def prepare_headers(self, token: Optional[str] = None) -> Dict[str, str]:
+    def prepare_headers(self, token: Optional[str] = None) -> dict[str, str]:
         headers = {}
         if token or self.token:
             headers["X-Consul-Token"] = token or self.token

--- a/consul/std.py
+++ b/consul/std.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 import requests
 from requests import Response
@@ -17,21 +17,21 @@ class HTTPClient(base.HTTPClient):
         response.encoding = "utf-8"
         return base.Response(response.status_code, response.headers, response.text)
 
-    def get(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
+    def get(self, callback, path, params=None, headers: Optional[dict[str, str]] = None):
         uri = self.uri(path, params)
         return callback(self.response(self.session.get(uri, headers=headers, verify=self.verify, cert=self.cert)))
 
-    def put(self, callback, path, params=None, data: str = "", headers: Optional[Dict[str, str]] = None):
+    def put(self, callback, path, params=None, data: str = "", headers: Optional[dict[str, str]] = None):
         uri = self.uri(path, params)
         return callback(
             self.response(self.session.put(uri, headers=headers, data=data, verify=self.verify, cert=self.cert))
         )
 
-    def delete(self, callback, path, params=None, headers: Optional[Dict[str, str]] = None):
+    def delete(self, callback, path, params=None, headers: Optional[dict[str, str]] = None):
         uri = self.uri(path, params)
         return callback(self.response(self.session.delete(uri, headers=headers, verify=self.verify, cert=self.cert)))
 
-    def post(self, callback, path, params=None, data: str = "", headers: Optional[Dict[str, str]] = None):
+    def post(self, callback, path, params=None, data: str = "", headers: Optional[dict[str, str]] = None):
         uri = self.uri(path, params)
         return callback(
             self.response(self.session.post(uri, headers=headers, data=data, verify=self.verify, cert=self.cert))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ disable = [
 ]
 
 [tool.ruff]
-target-version = 'py38'
+target-version = 'py39'
 line-length = 120
 exclude = [
     "docs/"


### PR DESCRIPTION
Drop 1.16 and support versions up to 1.20 (latest)
Use python3.9 as the default for linters.

[[chore] migrate pre-commit config](https://github.com/criteo/py-consul/commit/a18e79ac62ff2bfd8651c1ccc01f31ad4dffa352)
[[chore] Update linter default python version](https://github.com/criteo/py-consul/commit/14caa312025b13fa449c9df0c5de4875db16653f)
[Bump supported consul version (1.17 -> 1.20)](https://github.com/criteo/py-consul/commit/cf857a674578f6427fdc6bac1abe6359d2a74f8f)


Closes https://github.com/criteo/py-consul/issues/94