### PR TITLE
Adds gRPC health check support

### DIFF
--- a/consul/check.py
+++ b/consul/check.py
@@ -61,6 +61,35 @@ class Check:
         return ret
 
     @classmethod
+    def grpc(
+        cls, url: str, interval, use_tls=None, tls_skip_verify=None, timeout=None, deregister=None
+    ) -> dict[str, Any]:
+        """
+        Configures a gRPC health check that periodically assesses a service's health status.
+
+        This check performs a gRPC health check against the specified *url* at each *interval*
+        (e.g., "10s"). An optional *timeout* sets the maximum duration for each check attempt.
+        The *deregister* parameter specifies the time after which a consistently failing service
+        is automatically deregistered from Consul.
+
+        See also: consul grpc protocol
+            - https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+        """
+        ret = {
+            "grpc": url,
+            "interval": interval,
+        }
+        if use_tls is not None:
+            ret["grpc_use_tls"] = use_tls
+        if tls_skip_verify is not None:
+            ret["tls_skip_verify"] = tls_skip_verify
+        if timeout:
+            ret["timeout"] = timeout
+        if deregister:
+            ret["DeregisterCriticalServiceAfter"] = deregister
+        return ret
+
+    @classmethod
     def ttl(cls, ttl: str) -> dict[str, Any]:
         """
         Set check to be marked as critical after *ttl* (e.g. "10s") unless the

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -387,6 +387,133 @@ class TestChecks:
         assert ch == want
 
     @pytest.mark.parametrize(
+        ("url", "interval", "use_tls", "tls_skip_verify", "timeout", "deregister", "want"),
+        [
+            (
+                "localhost:10055",
+                "10s",
+                None,
+                None,
+                None,
+                None,
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                },
+            ),
+            (
+                "localhost:10055/:example.Service",
+                "10s",
+                None,
+                None,
+                None,
+                None,
+                {
+                    "grpc": "localhost:10055/:example.Service",
+                    "interval": "10s",
+                },
+            ),
+            (
+                "localhost:10055",
+                "10s",
+                True,
+                None,
+                None,
+                None,
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                    "grpc_use_tls": True,
+                },
+            ),
+            (
+                "localhost:10055",
+                "10s",
+                False,
+                None,
+                None,
+                None,
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                    "grpc_use_tls": False,
+                },
+            ),
+            (
+                "localhost:10055",
+                "10s",
+                None,
+                True,
+                None,
+                None,
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                    "tls_skip_verify": True,
+                },
+            ),
+            (
+                "localhost:10055",
+                "10s",
+                None,
+                False,
+                None,
+                None,
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                    "tls_skip_verify": False,
+                },
+            ),
+            (
+                "localhost:10055",
+                "10s",
+                None,
+                None,
+                "1s",
+                None,
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                    "timeout": "1s",
+                },
+            ),
+            (
+                "localhost:10055",
+                "10s",
+                None,
+                None,
+                None,
+                "1m",
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                    "DeregisterCriticalServiceAfter": "1m",
+                },
+            ),
+            (
+                "localhost:10055",
+                "10s",
+                True,
+                False,
+                "1s",
+                "1m",
+                {
+                    "grpc": "localhost:10055",
+                    "interval": "10s",
+                    "grpc_use_tls": True,
+                    "tls_skip_verify": False,
+                    "timeout": "1s",
+                    "DeregisterCriticalServiceAfter": "1m",
+                },
+            ),
+        ],
+    )
+    def test_grpc_check(self, url, interval, use_tls, tls_skip_verify, timeout, deregister, want) -> None:
+        ch = consul.check.Check.grpc(url, interval, use_tls, tls_skip_verify, timeout=timeout, deregister=deregister)
+        assert ch == want
+
+    @pytest.mark.parametrize(
         ("container_id", "shell", "script", "interval", "deregister", "want"),
         [
             (


### PR DESCRIPTION
- Introduces Check.grpc(...) to configure a gRPC health check for Consul, with optional TLS, timeout and deregistration.
- Maps parameters to Consul health check fields, including:
  - required: grpc (URL) and interval
  - optional: grpc_use_tls, tls_skip_verify, timeout, DeregisterCriticalServiceAfter
- Adds extensive unit tests covering various combinations of TLS, timeout, and deregistration to ensure correct dict output.
- Aligns with Consul's gRPC health check protocol and expected configuration structure.