### PR TITLE
api: add Config Entries and Discovery Chain endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,5 @@ repos:
       - id: mypy
         name: mypy
         language: system
-        entry: mypy --non-interactive --install-types
+        entry: mypy --show-traceback --no-sqlite-cache
         types: [python]

--- a/consul/api/config.py
+++ b/consul/api/config.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+import typing
+from typing import Any, TypedDict
+
+from consul.callback import CB
+
+if typing.TYPE_CHECKING:
+    import builtins
+
+
+class ConfigEntry(TypedDict, total=False):
+    Kind: str
+    Name: str
+    CreateIndex: int
+    ModifyIndex: int
+
+
+class Config:
+    """
+    Generic CRUD for Consul config entries (service-defaults, service-router,
+    service-splitter, service-resolver, service-intentions, ingress-gateway,
+    terminating-gateway, proxy-defaults, mesh, exported-services, api-gateway,
+    http-route, tcp-route, inline-certificate, file-system-certificate, and
+    others) via the single /v1/config endpoint. Required ACLs and the body
+    schema vary by *kind* -- see Consul's config entry reference for the
+    schema of each kind; this client does not model kind-specific fields.
+    """
+
+    def __init__(self, agent) -> None:
+        self.agent = agent
+
+    def set(
+        self,
+        kind: str,
+        name: str,
+        config_entry: builtins.dict[str, Any] | None = None,
+        token: str | None = None,
+        dc: str | None = None,
+        cas: int | None = None,
+    ) -> bool:
+        """
+        Creates or updates the config entry of *kind* named *name*.
+        :param kind: The config entry kind, e.g. "service-defaults".
+        :param name: The config entry name.
+        :param config_entry: The kind-specific body; merged with Kind/Name.
+        :param token: token with the write capability required by *kind* (varies by kind)
+        :param dc: Optional datacenter to target; defaults to the client's own dc.
+        :param cas: Optional ModifyIndex to check-and-set against; the write only
+            applies if it still matches the entry's current ModifyIndex.
+        :return: True if the config entry was created or updated
+        """
+        json_data: dict[str, Any] = dict(config_entry or {})
+        json_data["Kind"] = kind
+        json_data["Name"] = name
+
+        params: list[tuple[str, Any]] = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        if cas is not None:
+            params.append(("cas", cas))
+
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.json(), "/v1/config", params=params, headers=headers, data=json.dumps(json_data))
+
+    def get(self, kind: str, name: str, token: str | None = None, dc: str | None = None) -> ConfigEntry:
+        """
+        Reads the config entry of *kind* named *name*.
+        :param token: token with the read capability required by *kind*
+        :param dc: Optional datacenter to target; defaults to the client's own dc.
+        """
+        params: list[tuple[str, Any]] = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/config/{kind}/{name}", params=params, headers=headers)
+
+    def list(
+        self, kind: str, token: str | None = None, dc: str | None = None, filter_expr: str | None = None
+    ) -> builtins.list[ConfigEntry]:
+        """
+        Lists all config entries of *kind*.
+        :param token: token with the read capability required by *kind*
+        :param dc: Optional datacenter to target; defaults to the client's own dc.
+        :param filter_expr: Optional bexpr filter expression.
+        """
+        params: list[tuple[str, Any]] = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        if filter_expr:
+            params.append(("filter", filter_expr))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/config/{kind}", params=params, headers=headers)
+
+    def delete(
+        self, kind: str, name: str, token: str | None = None, dc: str | None = None, cas: int | None = None
+    ) -> bool:
+        """
+        Deletes the config entry of *kind* named *name*.
+        :param token: token with the write capability required by *kind*
+        :param dc: Optional datacenter to target; defaults to the client's own dc.
+        :param cas: Optional ModifyIndex to check-and-set against; the delete only
+            applies if it still matches the entry's current ModifyIndex. Without it,
+            deletion is unconditional (Consul returns an empty object rather than a
+            boolean in that case, hence the two different callbacks below).
+        :return: True if the config entry was deleted
+        """
+        params: list[tuple[str, Any]] = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        headers = self.agent.prepare_headers(token)
+        if cas is not None:
+            params.append(("cas", cas))
+            return self.agent.http.delete(CB.json(), f"/v1/config/{kind}/{name}", params=params, headers=headers)
+        return self.agent.http.delete(CB.boolean(), f"/v1/config/{kind}/{name}", params=params, headers=headers)

--- a/consul/api/discovery_chain.py
+++ b/consul/api/discovery_chain.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from typing import Any, TypedDict
+
+from consul.callback import CB
+
+
+class DiscoveryChainResponse(TypedDict, total=False):
+    Chain: dict[str, Any]
+
+
+class DiscoveryChain:
+    def __init__(self, agent) -> None:
+        self.agent = agent
+
+    def get(
+        self,
+        service: str,
+        compile_dc: str | None = None,
+        token: str | None = None,
+        override_connect_timeout: str | None = None,
+        override_protocol: str | None = None,
+        override_mesh_gateway_mode: str | None = None,
+    ) -> DiscoveryChainResponse:
+        """
+        Reads the compiled discovery chain for *service*. Uses POST instead of GET
+        whenever an override is supplied, matching Consul's documented behavior for
+        passing override parameters in the request body.
+        :param service: The service name to compile the discovery chain for.
+        :param compile_dc: Optional datacenter to use as the basis of compilation.
+        :param token: token with service:read capability
+        :param override_connect_timeout: Optional duration override, e.g. "10s".
+        :param override_protocol: Optional protocol override, e.g. "http".
+        :param override_mesh_gateway_mode: Optional mesh gateway Mode override, e.g. "local".
+        :return: The compiled discovery chain
+        """
+        params: list[tuple[str, Any]] = []
+        if compile_dc:
+            params.append(("compile-dc", compile_dc))
+        headers = self.agent.prepare_headers(token)
+
+        overrides: dict[str, Any] = {}
+        if override_connect_timeout:
+            overrides["OverrideConnectTimeout"] = override_connect_timeout
+        if override_protocol:
+            overrides["OverrideProtocol"] = override_protocol
+        if override_mesh_gateway_mode:
+            overrides["OverrideMeshGateway"] = {"Mode": override_mesh_gateway_mode}
+
+        if overrides:
+            return self.agent.http.post(
+                CB.json(),
+                f"/v1/discovery-chain/{service}",
+                params=params,
+                headers=headers,
+                data=json.dumps(overrides),
+            )
+        return self.agent.http.get(CB.json(), f"/v1/discovery-chain/{service}", params=params, headers=headers)

--- a/consul/base.py
+++ b/consul/base.py
@@ -14,6 +14,7 @@ from consul.api.catalog import Catalog
 from consul.api.config import Config
 from consul.api.connect import Connect
 from consul.api.coordinates import Coordinate
+from consul.api.discovery_chain import DiscoveryChain
 from consul.api.event import Event
 from consul.api.health import Health
 from consul.api.kv import KV
@@ -165,6 +166,7 @@ class Consul:
         self.operator = Operator(self)
         self.connect = Connect(self)
         self.config = Config(self)
+        self.discovery_chain = DiscoveryChain(self)
 
     def __enter__(self):
         return self

--- a/consul/base.py
+++ b/consul/base.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from consul.api.acl import ACL
 from consul.api.agent import Agent
 from consul.api.catalog import Catalog
+from consul.api.config import Config
 from consul.api.connect import Connect
 from consul.api.coordinates import Coordinate
 from consul.api.event import Event
@@ -163,6 +164,7 @@ class Consul:
         self.coordinate = Coordinate(self)
         self.operator = Operator(self)
         self.connect = Connect(self)
+        self.config = Config(self)
 
     def __enter__(self):
         return self

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -1,0 +1,52 @@
+class TestConfig:
+    def test_config_entry_crud(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        assert c.config.set(kind="service-defaults", name="test-svc", config_entry={"Protocol": "http"}) is True
+
+        entry = c.config.get(kind="service-defaults", name="test-svc")
+        assert entry["Kind"] == "service-defaults"
+        assert entry["Name"] == "test-svc"
+        assert entry["Protocol"] == "http"
+
+        entries = c.config.list(kind="service-defaults")
+        assert any(e["Name"] == "test-svc" for e in entries)
+
+        assert c.config.set(kind="service-defaults", name="test-svc", config_entry={"Protocol": "grpc"}) is True
+        updated = c.config.get(kind="service-defaults", name="test-svc")
+        assert updated["Protocol"] == "grpc"
+
+        assert c.config.delete(kind="service-defaults", name="test-svc") is True
+        assert c.config.get(kind="service-defaults", name="test-svc") is None
+
+    def test_config_entry_cas(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.config.set(kind="service-defaults", name="cas-svc", config_entry={"Protocol": "http"})
+        modify_index = c.config.get(kind="service-defaults", name="cas-svc")["ModifyIndex"]
+
+        # A stale cas value must not apply
+        stale_cas = int(modify_index) + 999999
+        assert (
+            c.config.set(kind="service-defaults", name="cas-svc", config_entry={"Protocol": "grpc"}, cas=stale_cas)
+            is False
+        )
+        assert c.config.get(kind="service-defaults", name="cas-svc")["Protocol"] == "http"
+
+        # The correct cas value applies
+        assert (
+            c.config.set(
+                kind="service-defaults", name="cas-svc", config_entry={"Protocol": "grpc"}, cas=int(modify_index)
+            )
+            is True
+        )
+        assert c.config.get(kind="service-defaults", name="cas-svc")["Protocol"] == "grpc"
+
+        # Deleting with a stale cas must not apply
+        modify_index = c.config.get(kind="service-defaults", name="cas-svc")["ModifyIndex"]
+        assert c.config.delete(kind="service-defaults", name="cas-svc", cas=int(modify_index) + 999999) is False
+        assert c.config.get(kind="service-defaults", name="cas-svc") is not None
+
+        # Deleting with the correct cas applies
+        assert c.config.delete(kind="service-defaults", name="cas-svc", cas=int(modify_index)) is True
+        assert c.config.get(kind="service-defaults", name="cas-svc") is None

--- a/tests/api/test_discovery_chain.py
+++ b/tests/api/test_discovery_chain.py
@@ -1,0 +1,14 @@
+class TestDiscoveryChain:
+    def test_discovery_chain_get(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.agent.service.register("web")
+
+        try:
+            chain = c.discovery_chain.get("web")
+            assert chain["Chain"]["ServiceName"] == "web"
+
+            overridden = c.discovery_chain.get("web", override_protocol="http")
+            assert overridden["Chain"]["ServiceName"] == "web"
+        finally:
+            c.agent.service.deregister("web")


### PR DESCRIPTION
## Summary

Phase 2 of the ongoing API-parity work (follow-up to #120). Adds two more endpoint groups:

- **Config Entries** (`consul/api/config.py`) — generic CRUD for `/v1/config`, covering all config entry kinds (service-defaults, service-router, service-splitter, service-resolver, proxy-defaults, mesh, ingress-gateway, terminating-gateway, exported-services, api-gateway, etc.) through one Kind/Name-based implementation rather than modeling every kind's schema individually. Includes `cas` (check-and-set) support on both `set()` and `delete()`.
- **Discovery Chain** (`consul/api/discovery_chain.py`) — `consul.discovery_chain.get()`, covering both the plain GET and the POST variant Consul requires when passing override parameters (connect timeout, protocol, mesh gateway mode).

**Not included, on purpose:**
- **Snapshot** — its response is a raw gzip binary blob, but the existing sync/async HTTP clients (`consul/std.py`, `consul/aio.py`) unconditionally decode every response body as UTF-8 text. Implementing Snapshot correctly needs a small transport-layer change (an opt-in raw/binary response mode) that's a distinct, separate piece of work deserving its own isolated review rather than being bundled into an "add a CRUD module" PR. Will follow up separately.
- **Peering** — deliberately deferred; no current consumer identified for cluster peering.

## A bug this surfaced

While testing `Config.set()`/`delete()` with `cas`, I found that `PUT /v1/config` always returns a literal JSON boolean (`true`/`false`) reflecting whether the CAS check passed — but `DELETE /v1/config/:kind/:name` returns an **empty object** (`{}`) when no `cas` is given, and only returns a real boolean when `cas` is passed. Using `CB.boolean()` (which only checks the HTTP status code, not body content) would have silently reported CAS failures as successes. Fixed by using `CB.json()` for `set()`, and branching between `CB.boolean()` / `CB.json()` in `delete()` based on whether `cas` was supplied. Verified against a live Consul instance before writing the test assertions.

## Base branch note

This branches off `master`, not off #120 — the two PRs touch disjoint files except for `.pre-commit-config.yaml`'s mypy fix, which is carried over here too (see last commit) since master doesn't have it yet. `ENDPOINT_STATUS.md` isn't touched in this PR since it doesn't exist on `master` yet (it's new in #120); I'll add Config Entries/Discovery Chain rows to it once this rebases past #120's merge.

## Test plan

- [x] `mypy consul/ --no-sqlite-cache` — clean
- [x] `ruff check .` / `ruff format --diff .` — clean
- [x] New integration tests in `tests/api/test_config.py` and `tests/api/test_discovery_chain.py`, run against real dockerized Consul (1.20.6/1.21.5/1.22.0) — all passing, including both CAS-success and CAS-failure paths on `set()` and `delete()`
- [x] Full existing test suite re-run — no regressions