### PR TITLE
api: round out Agent, Operator, Catalog, Health, Coordinate, Event endpoints

### DIFF
--- a/ENDPOINT_STATUS.md
+++ b/ENDPOINT_STATUS.md
@@ -31,12 +31,16 @@ File: `consul/api/agent.py`
 | `GET /v1/agent/members` | `Agent.members` | ✅ | (`segment` is Ent) |
 | `PUT /v1/agent/maintenance` | `Agent.maintenance` | ✅ | - |
 | `PUT /v1/agent/join/:address` | `Agent.join` | ✅ | - |
-| `PUT /v1/agent/leave` | - | ❌ | - |
+| `PUT /v1/agent/leave` | `Agent.leave` | ✅ | - |
 | `PUT /v1/agent/force-leave/:node` | `Agent.force_leave` | ⚠️ | `prune` (added v1.13) |
-| `PUT /v1/agent/reload` | - | ❌ | - |
-| `GET /v1/agent/metrics` | - | ❌ | - |
-| `GET /v1/agent/monitor` | - | ❌ | - |
-| `PUT /v1/agent/token/:type` | - | ❌ | All token update endpoints |
+| `PUT /v1/agent/reload` | `Agent.reload` | ✅ | - |
+| `GET /v1/agent/metrics` | `Agent.metrics` | ✅ | - |
+| `GET /v1/agent/monitor` | `Agent.monitor` | ⚠️ | Not true streaming — single blocking read, see docstring |
+| `PUT /v1/agent/token/default` | `Agent.Token.set_default` | ✅ | - |
+| `PUT /v1/agent/token/agent` | `Agent.Token.set_agent` | ✅ | - |
+| `PUT /v1/agent/token/agent_recovery` | `Agent.Token.set_agent_recovery` | ✅ | - |
+| `PUT /v1/agent/token/replication` | `Agent.Token.set_replication` | ✅ | - |
+| `PUT /v1/agent/token/config_file_service_registration` | `Agent.Token.set_config_file_service_registration` | ✅ | - |
 
 ### Agent Services
 | Endpoint | Python Method | Status | Missing Parameters |
@@ -66,25 +70,27 @@ File: `consul/api/catalog.py`
 
 | Endpoint | Python Method | Status | Missing Parameters |
 | :--- | :--- | :--- | :--- |
-| `PUT /v1/catalog/register` | `Catalog.register` | ⚠️ | `SkipNodeUpdate`, `TaggedAddresses` (in args) |
+| `PUT /v1/catalog/register` | `Catalog.register` | ✅ | - |
 | `PUT /v1/catalog/deregister` | `Catalog.deregister` | ✅ | - |
 | `GET /v1/catalog/datacenters` | `Catalog.datacenters` | ✅ | - |
-| `GET /v1/catalog/nodes` | `Catalog.nodes` | ⚠️ | `filter` |
-| `GET /v1/catalog/services` | `Catalog.services` | ⚠️ | `filter` |
-| `GET /v1/catalog/service/:service` | `Catalog.service` | ⚠️ | `filter` |
-| `GET /v1/catalog/connect/:service` | `Catalog.connect` | ⚠️ | `filter` |
-| `GET /v1/catalog/node/:node` | `Catalog.node` | ⚠️ | `filter` |
+| `GET /v1/catalog/nodes` | `Catalog.nodes` | ✅ | - |
+| `GET /v1/catalog/services` | `Catalog.services` | ✅ | - |
+| `GET /v1/catalog/service/:service` | `Catalog.service` | ✅ | - |
+| `GET /v1/catalog/connect/:service` | `Catalog.connect` | ✅ | - |
+| `GET /v1/catalog/node/:node` | `Catalog.node` | ✅ | - |
+| `GET /v1/catalog/gateway-services/:gateway` | `Catalog.gateway_services` | ✅ | - |
 
 ## 4. Health (`/v1/health`)
 File: `consul/api/health.py`
 
 | Endpoint | Python Method | Status | Missing Parameters |
 | :--- | :--- | :--- | :--- |
-| `GET /v1/health/node/:node` | `Health.node` | ⚠️ | `filter` |
-| `GET /v1/health/checks/:service` | `Health.checks` | ⚠️ | `filter` |
-| `GET /v1/health/service/:service` | `Health.service` | ⚠️ | `filter` |
-| `GET /v1/health/connect/:service` | `Health.connect` | ⚠️ | `filter` |
-| `GET /v1/health/state/:state` | `Health.state` | ⚠️ | `filter` |
+| `GET /v1/health/node/:node` | `Health.node` | ✅ | - |
+| `GET /v1/health/checks/:service` | `Health.checks` | ✅ | - |
+| `GET /v1/health/service/:service` | `Health.service` | ✅ | - |
+| `GET /v1/health/connect/:service` | `Health.connect` | ✅ | - |
+| `GET /v1/health/state/:state` | `Health.state` | ✅ | - |
+| `GET /v1/health/ingress/:service` | `Health.ingress` | ✅ | - |
 
 ## 5. Session (`/v1/session`)
 File: `consul/api/session.py`
@@ -140,8 +146,8 @@ File: `consul/api/event.py`
 
 | Endpoint | Python Method | Status | Missing Parameters |
 | :--- | :--- | :--- | :--- |
-| `PUT /v1/event/fire/:name` | `Event.fire` | ⚠️ | `dc` |
-| `GET /v1/event/list` | `Event.list` | ⚠️ | `node`, `service`, `tag` (filters) |
+| `PUT /v1/event/fire/:name` | `Event.fire` | ✅ | - |
+| `GET /v1/event/list` | `Event.list` | ✅ | `node`/`service`/`tag` accepted but observed to have no effect at list-time — see docstring |
 
 ## 8. Coordinate (`/v1/coordinate`)
 File: `consul/api/coordinates.py`
@@ -150,8 +156,8 @@ File: `consul/api/coordinates.py`
 | :--- | :--- | :--- | :--- |
 | `GET /v1/coordinate/datacenters` | `Coordinate.datacenters` | ✅ | - |
 | `GET /v1/coordinate/nodes` | `Coordinate.nodes` | ✅ | - |
-| `GET /v1/coordinate/node/:node` | - | ❌ | - |
-| `PUT /v1/coordinate/update` | - | ❌ | - |
+| `GET /v1/coordinate/node/:node` | `Coordinate.node` | ✅ | - |
+| `PUT /v1/coordinate/update` | `Coordinate.update` | ✅ | - |
 
 ## 9. Operator (`/v1/operator`)
 File: `consul/api/operator.py`
@@ -159,8 +165,16 @@ File: `consul/api/operator.py`
 | Endpoint | Python Method | Status | Missing Parameters |
 | :--- | :--- | :--- | :--- |
 | `GET /v1/operator/raft/configuration` | `Operator.raft_config` | ✅ | - |
-| `DELETE /v1/operator/raft/peer` | - | ❌ | - |
-| `GET /v1/operator/keyring` | - | ❌ | - |
+| `DELETE /v1/operator/raft/peer` | `Operator.raft_remove_peer` | ✅ | - |
+| `POST /v1/operator/raft/transfer-leader` | `Operator.raft_transfer_leader` | ✅ | - |
+| `GET /v1/operator/autopilot/configuration` | `Operator.autopilot_configuration` | ✅ | - |
+| `PUT /v1/operator/autopilot/configuration` | `Operator.update_autopilot_configuration` | ✅ | - |
+| `GET /v1/operator/autopilot/health` | `Operator.autopilot_health` | ✅ | - |
+| `GET /v1/operator/keyring` | `Operator.keyring_list` | ✅ | - |
+| `POST /v1/operator/keyring` | `Operator.keyring_install` | ✅ | - |
+| `PUT /v1/operator/keyring` | `Operator.keyring_use` | ✅ | - |
+| `DELETE /v1/operator/keyring` | `Operator.keyring_remove` | ✅ | - |
+| `GET /v1/operator/usage` | `Operator.usage` | ✅ | - |
 
 ## 10. Query (`/v1/query`)
 File: `consul/api/query.py`

--- a/consul/aio.py
+++ b/consul/aio.py
@@ -63,9 +63,19 @@ class HTTPClient(base.HTTPClient):
         uri = self.uri(path, params)
         return self._request(callback, "PUT", uri, headers=headers, data=data, connections_timeout=connections_timeout)
 
-    def delete(self, callback, path, params=None, headers: dict[str, str] | None = None, connections_timeout=None):
+    def delete(
+        self,
+        callback,
+        path,
+        params=None,
+        data: str | bytes = "",
+        headers: dict[str, str] | None = None,
+        connections_timeout=None,
+    ):
         uri = self.uri(path, params)
-        return self._request(callback, "DELETE", uri, headers=headers, connections_timeout=connections_timeout)
+        return self._request(
+            callback, "DELETE", uri, headers=headers, data=data, connections_timeout=connections_timeout
+        )
 
     def post(
         self,

--- a/consul/api/agent.py
+++ b/consul/api/agent.py
@@ -20,6 +20,7 @@ class Agent:
         self.service = Agent.Service(agent)
         self.check = Agent.Check(agent)
         self.connect = Agent.Connect(agent)
+        self.token = Agent.Token(agent)
 
     def self(self):
         """
@@ -129,6 +130,110 @@ class Agent:
 
         headers = self.agent.prepare_headers(token)
         return self.agent.http.put(CB.boolean(), f"/v1/agent/force-leave/{node}", headers=headers)
+
+    def leave(self, token: str | None = None):
+        """
+        Triggers a graceful leave and shutdown of the agent. It is used to
+        ensure other nodes see the agent as "left" instead of "failed".
+        Nodes that leave are permanently removed from the cluster's
+        membership until they rejoin. For agents running in server mode,
+        this also removes the node from the Raft peer set in a graceful
+        manner.
+
+        Note that calling this will actually terminate the agent process.
+
+        Requires a token with `agent:write` ACL capability.
+        """
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.boolean(), "/v1/agent/leave", headers=headers)
+
+    def reload(self, token: str | None = None):
+        """
+        Instructs the agent to reload its configuration. Not all
+        configuration options are reloadable, see the "Reloadable
+        Configuration" section of the Consul documentation for the set of
+        options that take effect via reload.
+
+        Requires a token with `agent:write` ACL capability.
+        """
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.boolean(), "/v1/agent/reload", headers=headers)
+
+    def metrics(self, format_prometheus: bool = False, token: str | None = None) -> Any:
+        """
+        Returns the metrics of the local agent for the most recent finished
+        interval. By default, the response is returned as JSON.
+
+        *format_prometheus* if set to *True*, returns the metrics formatted
+        as ``text/plain`` in the Prometheus exposition format instead of
+        JSON. Note that Prometheus output is only populated if the agent
+        was started with a positive
+        `telemetry.prometheus_retention_time` configured; otherwise Consul
+        returns an empty 200 response body (with an `X-Consul-Reason`
+        header explaining why) rather than an error.
+
+        Requires a token with `agent:read` ACL capability.
+        """
+        params = []
+        if format_prometheus:
+            params.append(("format", "prometheus"))
+        headers = self.agent.prepare_headers(token)
+
+        if format_prometheus:
+            # Prometheus output is plain text, not JSON, so CB.json() can't be used here.
+            def cb(response):
+                CB._status(response)  # pylint: disable=protected-access
+                return response.body
+
+            return self.agent.http.get(cb, "/v1/agent/metrics", params=params, headers=headers)
+
+        return self.agent.http.get(CB.json(), "/v1/agent/metrics", params=params, headers=headers)
+
+    def monitor(self, loglevel: str | None = None, logjson: bool = False, token: str | None = None) -> Any:
+        """
+        Streams logs from the local agent until the connection is closed.
+
+        *loglevel* is an optional log level to filter on, e.g. "trace",
+        "debug", "info", "warn", or "err". Defaults to "info" on the
+        Consul side if not supplied.
+
+        *logjson* if set to *True*, outputs each log line as JSON instead
+        of Consul's default plain-text log format.
+
+        Requires a token with `agent:read` ACL capability.
+
+        .. warning::
+            In real Consul this is a chunked/streaming endpoint that keeps
+            the connection open indefinitely, only sending data as new log
+            lines are produced; it does not close the connection on its
+            own. This client implementation is a first pass and does
+            **not** provide true streaming: it makes a single blocking GET
+            request and returns whatever text body has accumulated once
+            the connection ends. Neither the underlying sync nor async
+            HTTP clients in this library currently expose a per-call
+            socket/read timeout, so calling this method against a live,
+            long-running agent can block forever unless the connection is
+            closed by some other means (e.g. the agent shutting down, or a
+            timeout enforced by the caller, such as running this call in a
+            separate thread/task and cancelling it externally). Do not use
+            this method in latency-sensitive or production code paths
+            until true streaming support is added.
+        """
+        params = []
+        if loglevel:
+            params.append(("loglevel", loglevel))
+        if logjson:
+            params.append(("logjson", "true"))
+        headers = self.agent.prepare_headers(token)
+
+        def cb(response):
+            # the response body is plain text log lines (optionally one JSON
+            # object per line if logjson=True), never a single JSON document,
+            # so we can't use CB.json() here.
+            CB._status(response)  # pylint: disable=protected-access
+            return response.body
+
+        return self.agent.http.get(cb, "/v1/agent/monitor", params=params, headers=headers)
 
     class Service:
         def __init__(self, agent) -> None:
@@ -441,3 +546,92 @@ class Agent:
                 headers = self.agent.prepare_headers(token)
 
                 return self.agent.http.get(CB.json(), f"/v1/agent/connect/ca/leaf/{service}", headers=headers)
+
+    class Token:
+        """
+        Used to update the ACL tokens currently in use by the local agent.
+        See `here <https://developer.hashicorp.com/consul/api-docs/agent#update-acl-tokens>`_
+        for more information.
+
+        Tokens set this way are only persisted to disk (surviving an agent
+        restart) if the agent was started with
+        `acl.enable_token_persistence` set to *True*.
+        """
+
+        #: Literal path segments accepted by Consul for `PUT /v1/agent/token/:type`.
+        VALID_TOKEN_TYPES = frozenset({
+            "default",
+            "agent",
+            "agent_recovery",
+            "replication",
+            "config_file_service_registration",
+        })
+
+        def __init__(self, agent) -> None:
+            self.agent = agent
+
+        def set(self, token_type: str, secret: str, token: str | None = None) -> bool:
+            """
+            Sets the ACL token currently in use by the agent for *token_type*.
+
+            *token_type* must be one of "default", "agent", "agent_recovery",
+            "replication" or "config_file_service_registration". Note that
+            "agent_recovery" was named "agent_master" in Consul versions
+            prior to 1.11.
+
+            *secret* is the secret ID of the ACL token to set. Pass an
+            empty string to clear the currently configured token.
+
+            *token* is an optional ACL token to authenticate this request;
+            it requires `agent:write` ACL capability.
+
+            Returns *True* on success.
+            """
+            if token_type not in Agent.Token.VALID_TOKEN_TYPES:
+                raise ValueError(
+                    f"token_type must be one of {sorted(Agent.Token.VALID_TOKEN_TYPES)}, got {token_type!r}"
+                )
+            payload = {"Token": secret}
+            headers = self.agent.prepare_headers(token)
+            return self.agent.http.put(
+                CB.boolean(), f"/v1/agent/token/{token_type}", headers=headers, data=json.dumps(payload)
+            )
+
+        def set_default(self, secret: str, token: str | None = None) -> bool:
+            """
+            Sets the default ACL token used for both client requests and
+            to secure the agent's internal RPCs itself.
+            """
+            return self.set("default", secret, token=token)
+
+        def set_agent(self, secret: str, token: str | None = None) -> bool:
+            """
+            Sets the ACL token used for internal agent operations, such
+            as service/check registration and anti-entropy syncs. Falls
+            back to the "default" token if not set.
+            """
+            return self.set("agent", secret, token=token)
+
+        def set_agent_recovery(self, secret: str, token: str | None = None) -> bool:
+            """
+            Sets the ACL agent recovery token. This token can be used to
+            access agent endpoints even when the servers are unreachable,
+            e.g. for local troubleshooting. It was named "agent_master"
+            in Consul versions prior to 1.11.
+            """
+            return self.set("agent_recovery", secret, token=token)
+
+        def set_replication(self, secret: str, token: str | None = None) -> bool:
+            """
+            Sets the ACL replication token used to replicate ACLs, as
+            well as Connect Certificate Authority state and prepared
+            queries, to non-primary datacenters.
+            """
+            return self.set("replication", secret, token=token)
+
+        def set_config_file_service_registration(self, secret: str, token: str | None = None) -> bool:
+            """
+            Sets the ACL token used for service registrations declared in
+            the agent's local configuration files.
+            """
+            return self.set("config_file_service_registration", secret, token=token)

--- a/consul/api/catalog.py
+++ b/consul/api/catalog.py
@@ -9,7 +9,18 @@ class Catalog:
     def __init__(self, agent) -> None:
         self.agent = agent
 
-    def register(self, node, address, service=None, check=None, dc=None, token: str | None = None, node_meta=None):
+    def register(
+        self,
+        node,
+        address,
+        service=None,
+        check=None,
+        dc=None,
+        token: str | None = None,
+        node_meta=None,
+        skip_node_update: bool | None = None,
+        tagged_addresses=None,
+    ):
         """
         A low level mechanism for directly registering or updating entries
         in the catalog. It is usually recommended to use
@@ -62,6 +73,12 @@ class Catalog:
         *node_meta* is an optional meta data used for filtering, a
         dictionary formatted as {k1:v1, k2:v2}.
 
+        *skip_node_update* is an optional boolean which, if set to True,
+        skips updating the node's information in the registration.
+
+        *tagged_addresses* is an optional dictionary of tagged addresses
+        for the node, formatted as {k1:v1, k2:v2}.
+
         This manipulates the health check entry, but does not setup a
         script or TTL to actually update the status. The full documentation
         is `here <https://developer.hashicorp.com/consul/api-docs/catalog>`_.
@@ -84,6 +101,10 @@ class Catalog:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
+        if skip_node_update is not None:
+            data["SkipNodeUpdate"] = skip_node_update
+        if tagged_addresses:
+            data["TaggedAddresses"] = tagged_addresses
 
         headers = self.agent.prepare_headers(token)
         return self.agent.http.put(
@@ -128,7 +149,15 @@ class Catalog:
         return self.agent.http.get(CB.json(), "/v1/catalog/datacenters")
 
     def nodes(
-        self, index=None, wait=None, consistency=None, dc=None, near=None, token: str | None = None, node_meta=None
+        self,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        near=None,
+        token: str | None = None,
+        node_meta=None,
+        filter_expr: str | None = None,
     ):
         """
         Returns a tuple of (*index*, *nodes*) of all nodes known
@@ -153,6 +182,9 @@ class Catalog:
 
         *node_meta* is an optional meta data used for filtering, a
         dictionary formatted as {k1:v1, k2:v2}.
+
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
 
         The response looks like this::
 
@@ -184,10 +216,21 @@ class Catalog:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
+        if filter_expr:
+            params.append(("filter", filter_expr))
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), "/v1/catalog/nodes", params=params, headers=headers)
 
-    def services(self, index=None, wait=None, consistency=None, dc=None, token: str | None = None, node_meta=None):
+    def services(
+        self,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        token: str | None = None,
+        node_meta=None,
+        filter_expr: str | None = None,
+    ):
         """
         Returns a tuple of (*index*, *services*) of all services known
         about in the *dc* datacenter. *dc* defaults to the current
@@ -208,6 +251,9 @@ class Catalog:
 
         *node_meta* is an optional meta data used for filtering, a
         dictionary formatted as {k1:v1, k2:v2}.
+
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
 
         The response looks like this::
 
@@ -237,10 +283,21 @@ class Catalog:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
+        if filter_expr:
+            params.append(("filter", filter_expr))
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), "/v1/catalog/services", params=params, headers=headers)
 
-    def node(self, node, index=None, wait=None, consistency=None, dc=None, token: str | None = None):
+    def node(
+        self,
+        node,
+        index=None,
+        wait=None,
+        consistency=None,
+        dc=None,
+        token: str | None = None,
+        filter_expr: str | None = None,
+    ):
         """
         Returns a tuple of (*index*, *services*) of all services provided
         by *node*.
@@ -260,6 +317,9 @@ class Catalog:
         datacenter.
 
         *token* is an optional `ACL token`_ to apply to this request.
+
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
 
         The response looks like this::
 
@@ -297,6 +357,8 @@ class Catalog:
         consistency = consistency or self.agent.consistency
         if consistency in ("consistent", "stale"):
             params.append((consistency, "1"))
+        if filter_expr:
+            params.append(("filter", filter_expr))
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), f"/v1/catalog/node/{node}", params=params, headers=headers)
 
@@ -311,6 +373,9 @@ class Catalog:
         near=None,
         token: str | None = None,
         node_meta=None,
+        filter_expr: str | None = None,
+        peer: str | None = None,
+        merge_central_config: bool | None = None,
     ):
         params = []
         dc = dc or self.agent.dc
@@ -330,6 +395,12 @@ class Catalog:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
+        if filter_expr:
+            params.append(("filter", filter_expr))
+        if peer:
+            params.append(("peer", peer))
+        if merge_central_config:
+            params.append(("merge-central-config", "1"))
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), internal_uri, params=params, headers=headers)
 
@@ -361,6 +432,15 @@ class Catalog:
         *node_meta* is an optional meta data used for filtering, a
         dictionary formatted as {k1:v1, k2:v2}.
 
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
+
+        *peer* is an optional name of the peer that exported the service.
+
+        *merge_central_config* is an optional boolean which, if set to
+        True, merges the service's central configuration (proxy-defaults
+        and service-defaults) into the response.
+
         The response looks like this::
 
             (index, [
@@ -387,3 +467,74 @@ class Catalog:
         """
         internal_uri = f"/v1/catalog/connect/{service}"
         return self._service(internal_uri=internal_uri, **kwargs)
+
+    def gateway_services(self, gateway: str, dc=None, token: str | None = None):
+        """
+        Returns the services associated with an ingress or terminating
+        gateway.
+
+        *gateway* is the name of the gateway to list services for.
+
+        *dc* is the datacenter of the gateway and defaults to this agents
+        datacenter.
+
+        *token* is an optional `ACL token`_ to apply to this request.
+
+        The response looks like this for an ingress gateway::
+
+            [
+                {
+                    "Gateway": {
+                        "Name": "ingress-gateway",
+                        "Namespace": "default"
+                    },
+                    "Service": {
+                        "Name": "web",
+                        "Namespace": "default"
+                    },
+                    "GatewayKind": "ingress-gateway",
+                    "Port": 8080,
+                    "Protocol": "tcp",
+                    "Hosts": [],
+                    "CAFile": "",
+                    "CertFile": "",
+                    "KeyFile": "",
+                    "SNI": "",
+                    "FromWildcard": false,
+                    "CreateIndex": 16,
+                    "ModifyIndex": 16
+                }
+            ]
+
+        and like this for a terminating gateway::
+
+            [
+                {
+                    "Gateway": {
+                        "Name": "terminating-gateway",
+                        "Namespace": "default"
+                    },
+                    "Service": {
+                        "Name": "api",
+                        "Namespace": "default"
+                    },
+                    "GatewayKind": "terminating-gateway",
+                    "Port": 0,
+                    "Protocol": "",
+                    "Hosts": null,
+                    "CAFile": "/etc/certs/ca.pem",
+                    "CertFile": "/etc/certs/api/client.pem",
+                    "KeyFile": "/etc/certs/api/client.key",
+                    "SNI": "api.my-domain",
+                    "FromWildcard": false,
+                    "CreateIndex": 16,
+                    "ModifyIndex": 16
+                }
+            ]
+        """
+        params = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), f"/v1/catalog/gateway-services/{gateway}", params=params, headers=headers)

--- a/consul/api/coordinates.py
+++ b/consul/api/coordinates.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import json
+
 from consul.callback import CB
 
 
@@ -39,3 +43,60 @@ class Coordinate:
         if consistency in ("consistent", "stale"):
             params.append((consistency, "1"))
         return self.agent.http.get(CB.json(index=True), "/v1/coordinate/nodes", params=params)
+
+    def node(self, node: str, dc=None, index=None, wait=None, consistency=None):
+        """
+        Returns the LAN network coordinates for the node *node*.
+
+        *dc* is the datacenter that this agent will communicate with. By
+        default the datacenter of the host is used.
+
+        *index* is the current Consul index, suitable for making subsequent
+        calls to wait for changes since this query was last run.
+
+        *wait* the maximum duration to wait (e.g. '10s') to retrieve
+        a given index. this parameter is only applied if *index* is also
+        specified. the wait time by default is 5 minutes.
+
+        *consistency* can be either 'default', 'consistent' or 'stale'. if
+        not specified *consistency* will the consistency level this client
+        was configured with.
+        """
+        params = []
+        if dc:
+            params.append(("dc", dc))
+        if index:
+            params.append(("index", index))
+            if wait:
+                params.append(("wait", wait))
+        consistency = consistency or self.agent.consistency
+        if consistency in ("consistent", "stale"):
+            params.append((consistency, "1"))
+        return self.agent.http.get(CB.json(index=True), f"/v1/coordinate/node/{node}", params=params)
+
+    def update(self, node: str, coord: dict, segment: str | None = None, dc=None, token: str | None = None):
+        """
+        Updates the LAN network coordinates for the node *node*.
+
+        *coord* is the network coordinate, a dict with the keys 'Adjustment',
+        'Error', 'Height' and 'Vec', as returned by *coordinate.node* or
+        *coordinate.nodes*.
+
+        *segment* is the network segment the node belongs to. Enterprise
+        only.
+
+        *dc* is the datacenter that this agent will communicate with. By
+        default the datacenter of the host is used.
+
+        *token* is an optional `ACL token` to apply to this request. ACL
+        required : node:write
+
+        Returns *True* on success.
+        """
+        params = []
+        if dc:
+            params.append(("dc", dc))
+        data = {"Node": node, "Segment": segment or "", "Coord": coord}
+        data_str = json.dumps(data)
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(CB.boolean(), "/v1/coordinate/update", params=params, headers=headers, data=data_str)

--- a/consul/api/event.py
+++ b/consul/api/event.py
@@ -21,7 +21,7 @@ class Event:
     def __init__(self, agent) -> None:
         self.agent = agent
 
-    def fire(self, name: str, body: str = "", node=None, service=None, tag=None, token: str | None = None):
+    def fire(self, name: str, body: str = "", node=None, service=None, tag=None, dc=None, token: str | None = None):
         """
         Sends an event to Consul's gossip protocol.
 
@@ -40,12 +40,18 @@ class Event:
         agents will filter against to determine if they should store the
         event
 
+        *dc* is the datacenter to fire the event in. This will default to
+        the datacenter of the agent being queried.
+
         *token* is an optional `ACL token`_ to apply to this request. If
         the token's policy is not allowed to fire an event of this *name*
         an *ACLPermissionDenied* exception will be raised.
         """
         assert not name.startswith("/"), "keys should not start with a forward slash"
         params = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
         if node is not None:
             params.append(("node", node))
         if service is not None:
@@ -56,7 +62,7 @@ class Event:
         headers = self.agent.prepare_headers(token)
         return self.agent.http.put(CB.json(), f"/v1/event/fire/{name}", params=params, headers=headers, data=body)
 
-    def list(self, name: str | None = None, index=None, wait=None):
+    def list(self, name: str | None = None, index=None, wait=None, node=None, service=None, tag=None):
         """
         Returns a tuple of (*index*, *events*)
             Note: Since Consul's event protocol uses gossip, there is no
@@ -73,6 +79,9 @@ class Event:
         *wait* the maximum duration to wait (e.g. '10s') to retrieve
         a given index. This parameter is only applied if *index* is also
         specified. the wait time by default is 5 minutes.
+
+        *node*, *service*, and *tag* are regular expressions to filter the
+        returned events by node name, service name, and tag respectively.
 
         Consul agents only buffer the most recent entries. The current
         buffer size is 256, but this value could change in the future.
@@ -99,4 +108,10 @@ class Event:
             params.append(("index", index))
             if wait:
                 params.append(("wait", wait))
+        if node is not None:
+            params.append(("node", node))
+        if service is not None:
+            params.append(("service", service))
+        if tag is not None:
+            params.append(("tag", tag))
         return self.agent.http.get(CB.json(index=True, decode="Payload"), "/v1/event/list", params=params)

--- a/consul/api/health.py
+++ b/consul/api/health.py
@@ -8,6 +8,14 @@ class Health:
     def __init__(self, agent) -> None:
         self.agent = agent
 
+    @staticmethod
+    def _tag_params(tag: str | list[str] | None) -> list[tuple[str, str]]:
+        if tag is None:
+            return []
+        if not isinstance(tag, list):
+            tag = [tag]
+        return [("tag", tag_item) for tag_item in tag]
+
     def _service(
         self,
         internal_uri,
@@ -30,11 +38,7 @@ class Health:
                 params.append(("wait", wait))
         if passing:
             params.append(("passing", "1"))
-        if tag is not None:
-            if not isinstance(tag, list):
-                tag = [tag]
-            for tag_item in tag:
-                params.append(("tag", tag_item))
+        params.extend(self._tag_params(tag))
         dc = dc or self.agent.dc
         if dc:
             params.append(("dc", dc))

--- a/consul/api/health.py
+++ b/consul/api/health.py
@@ -19,6 +19,9 @@ class Health:
         near=None,
         token: str | None = None,
         node_meta=None,
+        filter_expr: str | None = None,
+        peer: str | None = None,
+        merge_central_config: bool = False,
     ):
         params = []
         if index:
@@ -40,6 +43,12 @@ class Health:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
+        if filter_expr:
+            params.append(("filter", filter_expr))
+        if peer:
+            params.append(("peer", peer))
+        if merge_central_config:
+            params.append(("merge-central-config", "1"))
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), internal_uri, params=params, headers=headers)
 
@@ -72,6 +81,17 @@ class Health:
 
         *node_meta* is an optional meta data used for filtering, a
         dictionary formatted as {k1:v1, k2:v2}.
+
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
+
+        *peer* is the name of the imported service's peer, and only applies
+        to imported services.
+
+        *merge_central_config* if set, will return a fully resolved
+        service definition that includes merged values from the
+        proxy-defaults/global and service-defaults/:service config
+        entries. Only applicable to connect-proxy and gateway services.
         """
         internal_uri = f"/v1/health/service/{service}"
         return self._service(internal_uri=internal_uri, **kwargs)
@@ -87,7 +107,79 @@ class Health:
         internal_uri = f"/v1/health/connect/{service}"
         return self._service(internal_uri=internal_uri, **kwargs)
 
-    def checks(self, service, index=None, wait=None, dc=None, near=None, token: str | None = None, node_meta=None):
+    def ingress(
+        self,
+        service: str,
+        index=None,
+        wait=None,
+        passing=None,
+        tag=None,
+        dc=None,
+        near=None,
+        token: str | None = None,
+        node_meta=None,
+        filter_expr: str | None = None,
+    ):
+        """
+        Returns a tuple of (*index*, *nodes*) of the ingress gateway
+        instances providing the given *service*.
+
+        *index* is the current Consul index, suitable for making subsequent
+        calls to wait for changes since this query was last run.
+
+        *wait* the maximum duration to wait (e.g. '10s') to retrieve
+        a given index. this parameter is only applied if *index* is also
+        specified. the wait time by default is 5 minutes.
+
+        Calling with *passing* set to True will filter results to only
+        those nodes whose checks are currently passing.
+
+        Calling with *tag* will filter the results by tag, multiple tags
+        using list possible.
+
+        *dc* is the datacenter of the node and defaults to this agents
+        datacenter.
+
+        *near* is a node name to sort the resulting list in ascending
+        order based on the estimated round trip time from that node
+
+        *token* is an optional `ACL token`_ to apply to this request.
+
+        *node_meta* is an optional meta data used for filtering, a
+        dictionary formatted as {k1:v1, k2:v2}.
+
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
+
+        Unlike `connect` and `service`, this endpoint does not support the
+        *peer* query parameter or the streaming backend for blocking
+        queries.
+        """
+        internal_uri = f"/v1/health/ingress/{service}"
+        return self._service(
+            internal_uri=internal_uri,
+            index=index,
+            wait=wait,
+            passing=passing,
+            tag=tag,
+            dc=dc,
+            near=near,
+            token=token,
+            node_meta=node_meta,
+            filter_expr=filter_expr,
+        )
+
+    def checks(
+        self,
+        service,
+        index=None,
+        wait=None,
+        dc=None,
+        near=None,
+        token: str | None = None,
+        node_meta=None,
+        filter_expr: str | None = None,
+    ):
         """
         Returns a tuple of (*index*, *checks*) with *checks* being the
         checks associated with the service.
@@ -111,6 +203,9 @@ class Health:
 
         *node_meta* is an optional meta data used for filtering, a
         dictionary formatted as {k1:v1, k2:v2}.
+
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
         """
         params = []
         if index:
@@ -125,10 +220,22 @@ class Health:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
+        if filter_expr:
+            params.append(("filter", filter_expr))
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), f"/v1/health/checks/{service}", params=params, headers=headers)
 
-    def state(self, name: str, index=None, wait=None, dc=None, near=None, token: str | None = None, node_meta=None):
+    def state(
+        self,
+        name: str,
+        index=None,
+        wait=None,
+        dc=None,
+        near=None,
+        token: str | None = None,
+        node_meta=None,
+        filter_expr: str | None = None,
+    ):
         """
         Returns a tuple of (*index*, *nodes*)
 
@@ -156,6 +263,9 @@ class Health:
         *node_meta* is an optional meta data used for filtering, a
         dictionary formatted as {k1:v1, k2:v2}.
 
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
+
         *nodes* are the nodes providing the given service.
         """
         assert name in ["any", "unknown", "passing", "warning", "critical"]
@@ -172,10 +282,20 @@ class Health:
         if node_meta:
             for nodemeta_name, nodemeta_value in node_meta.items():
                 params.append(("node-meta", f"{nodemeta_name}:{nodemeta_value}"))
+        if filter_expr:
+            params.append(("filter", filter_expr))
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), f"/v1/health/state/{name}", params=params, headers=headers)
 
-    def node(self, node, index=None, wait=None, dc=None, token: str | None = None):
+    def node(
+        self,
+        node,
+        index=None,
+        wait=None,
+        dc=None,
+        token: str | None = None,
+        filter_expr: str | None = None,
+    ):
         """
         Returns a tuple of (*index*, *checks*)
 
@@ -191,6 +311,9 @@ class Health:
 
         *token* is an optional `ACL token`_ to apply to this request.
 
+        *filter_expr* is an optional bexpr filter expression to filter the
+        results.
+
         *nodes* are the nodes providing the given service.
         """
         params = []
@@ -201,6 +324,8 @@ class Health:
         dc = dc or self.agent.dc
         if dc:
             params.append(("dc", dc))
+        if filter_expr:
+            params.append(("filter", filter_expr))
 
         headers = self.agent.prepare_headers(token)
         return self.agent.http.get(CB.json(index=True), f"/v1/health/node/{node}", params=params, headers=headers)

--- a/consul/api/operator.py
+++ b/consul/api/operator.py
@@ -1,4 +1,95 @@
+from __future__ import annotations
+
+import json
+import typing
+from typing import Any, TypedDict
+
 from consul.callback import CB
+from consul.exceptions import ConsulException
+
+if typing.TYPE_CHECKING:
+    import builtins
+
+    from consul.base import Response
+
+
+class AutopilotConfiguration(TypedDict, total=False):
+    CleanupDeadServers: bool
+    LastContactThreshold: str
+    MaxTrailingLogs: int
+    MinQuorum: int
+    ServerStabilizationTime: str
+    RedundancyZoneTag: str
+    DisableUpgradeMigration: bool
+    UpgradeVersionTag: str
+    CreateIndex: int
+    ModifyIndex: int
+
+
+class AutopilotServerHealth(TypedDict, total=False):
+    ID: str
+    Name: str
+    Address: str
+    SerfStatus: str
+    Version: str
+    Leader: bool
+    LastContact: str
+    LastTerm: int
+    LastIndex: int
+    Healthy: bool
+    Voter: bool
+    StableSince: str
+
+
+class AutopilotHealth(TypedDict, total=False):
+    Healthy: bool
+    FailureTolerance: int
+    Servers: builtins.list[AutopilotServerHealth]
+
+
+class KeyringResponse(TypedDict, total=False):
+    WAN: bool
+    Datacenter: str
+    Segment: str
+    Keys: dict[str, int]
+    PrimaryKeys: dict[str, int]
+    NumNodes: int
+
+
+class UsageDatacenter(TypedDict, total=False):
+    Services: int
+    ServiceInstances: int
+    ConnectServiceInstances: dict[str, int]
+    BillableServiceInstances: int
+    Nodes: int
+
+
+class UsageResponse(TypedDict, total=False):
+    Usage: dict[str, UsageDatacenter]
+    Index: int
+    LastContact: int
+    KnownLeader: bool
+    ConsistencyLevel: str
+    NotModified: bool
+    Backend: int
+    ResultsFilteredByACLs: bool
+
+
+def _autopilot_health_cb(response: Response) -> AutopilotHealth:
+    """
+    Callback for GET /v1/operator/autopilot/health.
+
+    Consul returns 200 when the cluster is healthy and 429 when it is not;
+    429 is a normal, expected "unhealthy" response with a full JSON body, not
+    an error, so it must not raise like the rest of the 4xx range does.
+    """
+    if response.code == 429:
+        try:
+            data = json.loads(response.body)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise ConsulException(f"Failed to decode JSON: {response.body} {e}") from e
+        return data
+    return CB.json()(response)
 
 
 class Operator:
@@ -10,3 +101,249 @@ class Operator:
         Returns raft configuration.
         """
         return self.agent.http.get(CB.json(), "/v1/operator/raft/configuration")
+
+    def raft_remove_peer(
+        self, address: str | None = None, peer_id: str | None = None, token: str | None = None
+    ) -> bool:
+        """
+        Removes the Consul server with given address or ID from the Raft
+        configuration. Requires a token with operator:write capability.
+
+        Exactly one of *address* or *peer_id* should be supplied, per Consul's
+        raft/peer API.
+        :param address: The address (host:port) of the peer to remove.
+        :param peer_id: The ID of the peer to remove.
+        :param token: token with operator:write capability
+        :return: True if the request succeeded
+        """
+        params: list[tuple[str, Any]] = []
+        if address:
+            params.append(("address", address))
+        if peer_id:
+            params.append(("id", peer_id))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.delete(CB.boolean(), "/v1/operator/raft/peer", params=params, headers=headers)
+
+    def raft_transfer_leader(self, peer_id: str | None = None, token: str | None = None) -> bool:
+        """
+        Transfers Raft leadership away from the current leader to another
+        peer. Requires a token with operator:write capability.
+        :param peer_id: Optional node ID of the peer to transfer leadership
+            to. If not specified, Consul selects a peer at random.
+        :param token: token with operator:write capability
+        :return: True if the request succeeded
+        """
+        params: list[tuple[str, Any]] = []
+        if peer_id:
+            params.append(("id", peer_id))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.post(CB.boolean(), "/v1/operator/raft/transfer-leader", params=params, headers=headers)
+
+    def autopilot_configuration(self, token: str | None = None, dc: str | None = None) -> AutopilotConfiguration:
+        """
+        Returns the current Autopilot configuration. Requires a token with
+        operator:read capability.
+        :param token: token with operator:read capability
+        :param dc: Optional datacenter to target; defaults to the client's own dc.
+        :return: the Autopilot configuration
+        """
+        params: list[tuple[str, Any]] = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), "/v1/operator/autopilot/configuration", params=params, headers=headers)
+
+    def update_autopilot_configuration(
+        self,
+        cleanup_dead_servers: bool | None = None,
+        last_contact_threshold: str | None = None,
+        max_trailing_logs: int | None = None,
+        min_quorum: int | None = None,
+        server_stabilization_time: str | None = None,
+        redundancy_zone_tag: str | None = None,
+        disable_upgrade_migration: bool | None = None,
+        upgrade_version_tag: str | None = None,
+        cas: int | None = None,
+        token: str | None = None,
+        dc: str | None = None,
+    ) -> bool:
+        """
+        Updates the Autopilot configuration. Requires a token with
+        operator:write capability.
+        :param cleanup_dead_servers: Optional, whether to remove dead servers
+            from the Raft peer list when a new server joins.
+        :param last_contact_threshold: Optional duration, e.g. "200ms".
+        :param max_trailing_logs: Optional maximum number of log entries a
+            server can trail the leader by before being considered unhealthy.
+        :param min_quorum: Optional minimum number of servers to maintain
+            before autopilot allows a dead server to be removed.
+        :param server_stabilization_time: Optional duration, e.g. "10s".
+        :param redundancy_zone_tag: Optional -autopilot-redundancy-zone-tag value.
+        :param disable_upgrade_migration: Optional, disables Autopilot's
+            upgrade migration strategy.
+        :param upgrade_version_tag: Optional tag used to override the version
+            used during a migration.
+        :param cas: Optional Autopilot ModifyIndex to check-and-set against;
+            the write only applies if it still matches the current
+            configuration's ModifyIndex. Consul always replies with HTTP 200
+            here, encoding the actual success/failure of the cas as a JSON
+            boolean body, hence the CB.json() callback below rather than
+            CB.boolean() (which only looks at the status code).
+        :param token: token with operator:write capability
+        :param dc: Optional datacenter to target; defaults to the client's own dc.
+        :return: True if the update was applied. When *cas* is supplied and does
+            not match the current ModifyIndex, False is returned instead of
+            raising an error.
+        """
+        json_data: dict[str, Any] = {}
+        if cleanup_dead_servers is not None:
+            json_data["CleanupDeadServers"] = cleanup_dead_servers
+        if last_contact_threshold is not None:
+            json_data["LastContactThreshold"] = last_contact_threshold
+        if max_trailing_logs is not None:
+            json_data["MaxTrailingLogs"] = max_trailing_logs
+        if min_quorum is not None:
+            json_data["MinQuorum"] = min_quorum
+        if server_stabilization_time is not None:
+            json_data["ServerStabilizationTime"] = server_stabilization_time
+        if redundancy_zone_tag is not None:
+            json_data["RedundancyZoneTag"] = redundancy_zone_tag
+        if disable_upgrade_migration is not None:
+            json_data["DisableUpgradeMigration"] = disable_upgrade_migration
+        if upgrade_version_tag is not None:
+            json_data["UpgradeVersionTag"] = upgrade_version_tag
+
+        params: list[tuple[str, Any]] = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        if cas is not None:
+            params.append(("cas", cas))
+
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(
+            CB.json(),
+            "/v1/operator/autopilot/configuration",
+            params=params,
+            headers=headers,
+            data=json.dumps(json_data),
+        )
+
+    def autopilot_health(self, token: str | None = None, dc: str | None = None) -> AutopilotHealth:
+        """
+        Returns the current health of the servers, as tracked by Autopilot.
+        Requires a token with operator:read capability.
+
+        Consul responds with HTTP 200 when the cluster is healthy and HTTP
+        429 when it is not; both responses carry the same JSON body shape,
+        distinguished by the "Healthy" field, so neither raises an exception.
+        :param token: token with operator:read capability
+        :param dc: Optional datacenter to target; defaults to the client's own dc.
+        :return: the Autopilot health snapshot
+        """
+        params: list[tuple[str, Any]] = []
+        dc = dc or self.agent.dc
+        if dc:
+            params.append(("dc", dc))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(
+            _autopilot_health_cb, "/v1/operator/autopilot/health", params=params, headers=headers
+        )
+
+    def keyring_list(
+        self, relay_factor: int | None = None, local_only: bool | None = None, token: str | None = None
+    ) -> builtins.list[KeyringResponse]:
+        """
+        Lists the gossip encryption keys installed on every member of the
+        WAN and LAN rings. Requires a token with keyring:read capability.
+        :param relay_factor: Optional number of extra nodes to relay the
+            response through, between 0 and 5.
+        :param local_only: Optional, if True, restricts the response to
+            queries against the local datacenter's LAN ring only.
+        :param token: token with keyring:read capability
+        :return: a list of key/ring status entries, one per WAN/LAN ring
+        """
+        params: list[tuple[str, Any]] = []
+        if relay_factor is not None:
+            params.append(("relay-factor", relay_factor))
+        if local_only is not None:
+            params.append(("local-only", "true" if local_only else "false"))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), "/v1/operator/keyring", params=params, headers=headers)
+
+    def keyring_install(self, key: str, relay_factor: int | None = None, token: str | None = None) -> bool:
+        """
+        Installs a new gossip encryption key onto every member of the WAN
+        and LAN rings. Requires a token with keyring:write capability.
+        :param key: The base64-encoded gossip encryption key to install.
+        :param relay_factor: Optional number of extra nodes to relay the
+            request through, between 0 and 5.
+        :param token: token with keyring:write capability
+        :return: True if the request succeeded
+        """
+        params: list[tuple[str, Any]] = []
+        if relay_factor is not None:
+            params.append(("relay-factor", relay_factor))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.post(
+            CB.boolean(), "/v1/operator/keyring", params=params, headers=headers, data=json.dumps({"Key": key})
+        )
+
+    def keyring_use(self, key: str, relay_factor: int | None = None, token: str | None = None) -> bool:
+        """
+        Changes the primary gossip encryption key used on every member of
+        the WAN and LAN rings. The key must already be installed before it
+        can be used as the primary key. Requires a token with
+        keyring:write capability.
+        :param key: The base64-encoded gossip encryption key to use as primary.
+        :param relay_factor: Optional number of extra nodes to relay the
+            request through, between 0 and 5.
+        :param token: token with keyring:write capability
+        :return: True if the request succeeded
+        """
+        params: list[tuple[str, Any]] = []
+        if relay_factor is not None:
+            params.append(("relay-factor", relay_factor))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.put(
+            CB.boolean(), "/v1/operator/keyring", params=params, headers=headers, data=json.dumps({"Key": key})
+        )
+
+    def keyring_remove(self, key: str, relay_factor: int | None = None, token: str | None = None) -> bool:
+        """
+        Removes a gossip encryption key from every member of the WAN and
+        LAN rings. Requires a token with keyring:write capability.
+        :param key: The base64-encoded gossip encryption key to remove.
+        :param relay_factor: Optional number of extra nodes to relay the
+            request through, between 0 and 5.
+        :param token: token with keyring:write capability
+        :return: True if the request succeeded
+        """
+        params: list[tuple[str, Any]] = []
+        if relay_factor is not None:
+            params.append(("relay-factor", relay_factor))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.delete(
+            CB.boolean(), "/v1/operator/keyring", params=params, headers=headers, data=json.dumps({"Key": key})
+        )
+
+    def usage(self, global_: bool | None = None, stale: bool | None = None, token: str | None = None) -> UsageResponse:
+        """
+        Returns key metrics about the cluster, such as the number of
+        services, service instances, and nodes. Requires a token with
+        operator:read capability.
+        :param global_: Optional, if True, returns usage information for
+            all known datacenters instead of just the client's own dc.
+        :param stale: Optional, if True, allows reading the data from any
+            server, not just the leader.
+        :param token: token with operator:read capability
+        :return: cluster usage statistics
+        """
+        params: list[tuple[str, Any]] = []
+        if global_ is not None:
+            params.append(("global", "true" if global_ else "false"))
+        if stale is not None:
+            params.append(("stale", "true" if stale else "false"))
+        headers = self.agent.prepare_headers(token)
+        return self.agent.http.get(CB.json(), "/v1/operator/usage", params=params, headers=headers)

--- a/consul/base.py
+++ b/consul/base.py
@@ -64,7 +64,7 @@ class HTTPClient(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def delete(self, callback, path, params=None, headers: dict[str, str] | None = None):
+    def delete(self, callback, path, params=None, data: str | bytes = "", headers: dict[str, str] | None = None):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/consul/std.py
+++ b/consul/std.py
@@ -27,9 +27,11 @@ class HTTPClient(base.HTTPClient):
             self.response(self.session.put(uri, headers=headers, data=data, verify=self.verify, cert=self.cert))
         )
 
-    def delete(self, callback, path, params=None, headers: dict[str, str] | None = None):
+    def delete(self, callback, path, params=None, data: str | bytes = "", headers: dict[str, str] | None = None):
         uri = self.uri(path, params)
-        return callback(self.response(self.session.delete(uri, headers=headers, verify=self.verify, cert=self.cert)))
+        return callback(
+            self.response(self.session.delete(uri, headers=headers, data=data, verify=self.verify, cert=self.cert))
+        )
 
     def post(self, callback, path, params=None, data: str = "", headers: dict[str, str] | None = None):
         uri = self.uri(path, params)

--- a/tests/api/test_agent.py
+++ b/tests/api/test_agent.py
@@ -1,8 +1,10 @@
 import time
 
 import pytest
+import requests
 
 import consul.check
+import consul.exceptions
 from tests.utils import should_skip
 
 Check = consul.check.Check
@@ -285,3 +287,87 @@ class TestAgent:
         assert "foo_connect-sidecar-proxy" in services
 
         assert c.agent.service.deregister("foo_connect") is True
+
+    def test_agent_reload(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+        assert c.agent.reload() is True
+
+    def test_agent_metrics(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        metrics = c.agent.metrics()
+        assert "Timestamp" in metrics
+        assert "Gauges" in metrics
+
+        # Without `telemetry.prometheus_retention_time` configured on the
+        # agent, Consul returns a 200 with an empty body instead of an
+        # error (see X-Consul-Reason header), so we can only assert that
+        # the call succeeds and returns a string, not that it looks like
+        # real Prometheus exposition text.
+        prometheus_metrics = c.agent.metrics(format_prometheus=True)
+        assert isinstance(prometheus_metrics, str)
+
+    def test_agent_monitor_rejects_invalid_loglevel(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # Only the fast-fail path is safely testable here: an invalid loglevel
+        # is rejected by Consul with a 400 before any streaming begins. The
+        # success path genuinely never closes the connection (see the warning
+        # on Agent.monitor's docstring), and neither the sync nor async HTTP
+        # clients in this library expose a per-call socket timeout, so there
+        # is no way to bound a real call from a test without either leaking a
+        # thread that blocks interpreter shutdown (concurrent.futures.
+        # ThreadPoolExecutor's own atexit handler joins worker threads
+        # unconditionally, even after shutdown(wait=False)) or adding timeout
+        # support to the transport layer, which is out of scope here.
+        with pytest.raises(consul.exceptions.BadRequest):
+            c.agent.monitor(loglevel="not-a-real-level")
+
+    def test_agent_token_permission_denied(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # ACLs are disabled on this instance, so Consul rejects all token
+        # updates with ACLDisabled ("ACL support disabled").
+        with pytest.raises(consul.exceptions.ACLDisabled):
+            c.agent.token.set_default("some-secret")
+
+    def test_agent_token_invalid_type(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        with pytest.raises(ValueError, match="token_type must be one of"):
+            c.agent.token.set("not-a-real-token-type", "some-secret")
+
+    def test_agent_token_set(self, acl_consul) -> None:
+        c, master_token, _consul_version = acl_consul
+
+        assert c.agent.token.set_default("default-secret", token=master_token) is True
+        assert c.agent.token.set_agent("agent-secret", token=master_token) is True
+        assert c.agent.token.set_agent_recovery("agent-recovery-secret", token=master_token) is True
+        assert c.agent.token.set_replication("replication-secret", token=master_token) is True
+        assert c.agent.token.set_config_file_service_registration("config-file-secret", token=master_token) is True
+
+        # Generic set() should behave the same as the convenience wrappers.
+        assert c.agent.token.set("default", "default-secret-2", token=master_token) is True
+
+    def test_agent_leave(self, consul_instance) -> None:
+        # PUT /v1/agent/leave triggers a graceful shutdown of the agent
+        # process itself, so this must run against a dedicated instance
+        # and not one shared with other tests.
+        c = consul.Consul(port=consul_instance.port)
+
+        assert c.agent.leave() is True
+
+        # Give the agent a moment to actually exit, then confirm it is no
+        # longer reachable.
+        deadline = time.time() + 5
+        last_error = None
+        while time.time() < deadline:
+            try:
+                requests.get(f"http://127.0.0.1:{consul_instance.port}/v1/status/leader", timeout=1)
+                time.sleep(0.2)
+            except requests.exceptions.RequestException as e:
+                last_error = e
+                break
+        else:
+            pytest.fail("agent was still reachable after leave()")
+        assert last_error is not None

--- a/tests/api/test_catalog.py
+++ b/tests/api/test_catalog.py
@@ -1,63 +1,209 @@
+import time
+
+import pytest
+
+import consul
+
+
 class TestCatalog:
-    pass
-    # def test_catalog(self, consul_obj):
-    #     c, _consul_version = consul_obj
-    #
-    #     # grab the node our server created, so we can ignore it
-    #     _, nodes = c.catalog.nodes()
-    #     assert len(nodes) == 1
-    #     current = nodes[0]
-    #
-    #     # test catalog.datacenters
-    #     assert c.catalog.datacenters() == ["dc1"]
-    #
-    #     # test catalog.register
-    #     pytest.raises(consul.ConsulException, c.catalog.register, "foo", "10.1.10.11", dc="dc2")
-    #
-    #     assert c.catalog.register("n1", "10.1.10.11", service={"service": "s1"}, check={"name": "c1"}) is True
-    #     assert c.catalog.register("n1", "10.1.10.11", service={"service": "s2"}) is True
-    #     assert c.catalog.register("n2", "10.1.10.12", service={"service": "s1", "tags": ["master"]}) is True
-    #
-    #     # test catalog.nodes
-    #     pytest.raises(consul.ConsulException, c.catalog.nodes, dc="dc2")
-    #     _, nodes = c.catalog.nodes()
-    #     nodes.remove(current)
-    #     assert [x["Node"] for x in nodes] == ["n1", "n2"]
-    #
-    #     # test catalog.services
-    #     pytest.raises(consul.ConsulException, c.catalog.services, dc="dc2")
-    #     _, services = c.catalog.services()
-    #     assert services == {"s1": ["master"], "s2": [], "consul": []}
-    #
-    #     # test catalog.node
-    #     pytest.raises(consul.ConsulException, c.catalog.node, "n1", dc="dc2")
-    #     _, node = c.catalog.node("n1")
-    #     assert set(node["Services"].keys()) == {"s1", "s2"}
-    #     _, node = c.catalog.node("n3")
-    #     assert node is None
-    #
-    #     # test catalog.service
-    #     pytest.raises(consul.ConsulException, c.catalog.service, "s1", dc="dc2")
-    #     _, nodes = c.catalog.service("s1")
-    #     assert {x["Node"] for x in nodes} == {"n1", "n2"}
-    #     _, nodes = c.catalog.service("s1", tag="master")
-    #     assert {x["Node"] for x in nodes} == {"n2"}
-    #
-    #     # test catalog.deregister
-    #     pytest.raises(consul.ConsulException, c.catalog.deregister, "n2", dc="dc2")
-    #     assert c.catalog.deregister("n1", check_id="c1") is True
-    #     assert c.catalog.deregister("n2", service_id="s1") is True
-    #     # check the nodes weren't removed
-    #     _, nodes = c.catalog.nodes()
-    #     nodes.remove(current)
-    #     assert [x["Node"] for x in nodes] == ["n1", "n2"]
-    #     # check n2's s1 service was removed though
-    #     _, nodes = c.catalog.service("s1")
-    #     assert {x["Node"] for x in nodes} == {"n1"}
-    #
-    #     # cleanup
-    #     assert c.catalog.deregister("n1") is True
-    #     assert c.catalog.deregister("n2") is True
-    #     _, nodes = c.catalog.nodes()
-    #     nodes.remove(current)
-    #     assert [x["Node"] for x in nodes] == []
+    def test_catalog(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # grab the node our server created, so we can ignore it
+        _, nodes = c.catalog.nodes()
+        assert len(nodes) == 1
+        current = nodes[0]
+
+        # test catalog.datacenters
+        assert c.catalog.datacenters() == ["dc1"]
+
+        # test catalog.register
+        pytest.raises(consul.ConsulException, c.catalog.register, "foo", "10.1.10.11", dc="dc2")
+
+        assert c.catalog.register("n1", "10.1.10.11", service={"service": "s1"}, check={"name": "c1"}) is True
+        assert c.catalog.register("n1", "10.1.10.11", service={"service": "s2"}) is True
+        assert c.catalog.register("n2", "10.1.10.12", service={"service": "s1", "tags": ["master"]}) is True
+
+        # test catalog.nodes
+        pytest.raises(consul.ConsulException, c.catalog.nodes, dc="dc2")
+        _, nodes = c.catalog.nodes()
+        nodes.remove(current)
+        assert [x["Node"] for x in nodes] == ["n1", "n2"]
+
+        # test catalog.services
+        pytest.raises(consul.ConsulException, c.catalog.services, dc="dc2")
+        _, services = c.catalog.services()
+        assert services == {"s1": ["master"], "s2": [], "consul": []}
+
+        # test catalog.node
+        pytest.raises(consul.ConsulException, c.catalog.node, "n1", dc="dc2")
+        _, node = c.catalog.node("n1")
+        assert set(node["Services"].keys()) == {"s1", "s2"}
+        _, node = c.catalog.node("n3")
+        assert node is None
+
+        # test catalog.service
+        pytest.raises(consul.ConsulException, c.catalog.service, "s1", dc="dc2")
+        _, nodes = c.catalog.service("s1")
+        assert {x["Node"] for x in nodes} == {"n1", "n2"}
+        _, nodes = c.catalog.service("s1", tag="master")
+        assert {x["Node"] for x in nodes} == {"n2"}
+
+        # test catalog.deregister
+        pytest.raises(consul.ConsulException, c.catalog.deregister, "n2", dc="dc2")
+        assert c.catalog.deregister("n1", check_id="c1") is True
+        assert c.catalog.deregister("n2", service_id="s1") is True
+        # check the nodes weren't removed
+        _, nodes = c.catalog.nodes()
+        nodes.remove(current)
+        assert [x["Node"] for x in nodes] == ["n1", "n2"]
+        # check n2's s1 service was removed though
+        _, nodes = c.catalog.service("s1")
+        assert {x["Node"] for x in nodes} == {"n1"}
+
+        # cleanup
+        assert c.catalog.deregister("n1") is True
+        assert c.catalog.deregister("n2") is True
+        _, nodes = c.catalog.nodes()
+        nodes.remove(current)
+        assert [x["Node"] for x in nodes] == []
+
+    def test_catalog_register_skip_node_update_and_tagged_addresses(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        tagged_addresses = {"lan": "10.1.10.11", "wan": "10.1.10.21"}
+        assert (
+            c.catalog.register(
+                "n-tagged",
+                "10.1.10.11",
+                service={"service": "s-tagged"},
+                tagged_addresses=tagged_addresses,
+            )
+            is True
+        )
+
+        _, node = c.catalog.node("n-tagged")
+        assert node["Node"]["TaggedAddresses"]["lan"] == "10.1.10.11"
+        assert node["Node"]["TaggedAddresses"]["wan"] == "10.1.10.21"
+
+        # SkipNodeUpdate=True should not error and the node's address stays
+        # untouched (registering with the same address so this is a no-op
+        # check, but exercises the wire format of the flag).
+        assert (
+            c.catalog.register(
+                "n-tagged",
+                "10.1.10.11",
+                service={"service": "s-tagged"},
+                skip_node_update=True,
+            )
+            is True
+        )
+
+        _, node = c.catalog.node("n-tagged")
+        assert node["Node"]["Address"] == "10.1.10.11"
+
+        assert c.catalog.deregister("n-tagged") is True
+
+    def test_catalog_filter(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        assert c.catalog.register("n-filter-1", "10.1.10.31", service={"service": "web", "tags": ["prod"]}) is True
+        assert c.catalog.register("n-filter-2", "10.1.10.32", service={"service": "web", "tags": ["staging"]}) is True
+
+        # catalog.nodes filter
+        _, nodes = c.catalog.nodes(filter_expr='Node == "n-filter-1"')
+        assert [x["Node"] for x in nodes] == ["n-filter-1"]
+
+        # catalog.services filter
+        _, services = c.catalog.services(filter_expr='"prod" in ServiceTags')
+        assert services == {"web": ["prod"]}
+
+        # catalog.node filter -- the filter expression is evaluated against
+        # each entry of the "Services" map, not the top-level document.
+        _, node = c.catalog.node("n-filter-1", filter_expr='Service == "web"')
+        assert node is not None
+        assert "web" in node["Services"]
+        _, node = c.catalog.node("n-filter-1", filter_expr='Service == "does-not-exist"')
+        assert node["Services"] == {}
+
+        # catalog.service filter
+        _, nodes = c.catalog.service("web", filter_expr='"prod" in ServiceTags')
+        assert {x["Node"] for x in nodes} == {"n-filter-1"}
+
+        # catalog.connect filter (connect-capable nodes for a plain service
+        # is empty, but the filter param must still be accepted and produce
+        # a well-formed, successful request)
+        _, nodes = c.catalog.connect("web", filter_expr='"prod" in ServiceTags')
+        assert nodes == []
+
+        # malformed bexpr should raise a clear ConsulException from Consul
+        pytest.raises(consul.ConsulException, c.catalog.nodes, filter_expr="not a valid expression((")
+
+        assert c.catalog.deregister("n-filter-1") is True
+        assert c.catalog.deregister("n-filter-2") is True
+
+    def test_catalog_service_merge_central_config(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        assert c.catalog.register("n-mcc", "10.1.10.41", service={"service": "web-mcc", "port": 8080}) is True
+
+        _, nodes = c.catalog.service("web-mcc", merge_central_config=True)
+        assert {x["Node"] for x in nodes} == {"n-mcc"}
+        assert nodes[0]["ServicePort"] == 8080
+
+        _, nodes = c.catalog.connect("web-mcc", merge_central_config=True)
+        assert nodes == []
+
+        assert c.catalog.deregister("n-mcc") is True
+
+    def test_catalog_service_peer_unknown(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # querying with a peer name that doesn't exist returns no results
+        # rather than erroring, this simply verifies the query param is
+        # wired through correctly end-to-end.
+        _, nodes = c.catalog.service("web", peer="unknown-peer")
+        assert nodes == []
+
+        _, nodes = c.catalog.connect("web", peer="unknown-peer")
+        assert nodes == []
+
+    def test_catalog_gateway_services(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # no gateway registered yet: empty list of services
+        services = c.catalog.gateway_services("ingress-gateway-1")
+        assert services == []
+
+        assert (
+            c.catalog.register(
+                "n-gw",
+                "10.1.10.51",
+                service={"service": "ingress-gateway-1", "kind": "ingress-gateway"},
+            )
+            is True
+        )
+        assert c.catalog.register("n-gw", "10.1.10.51", service={"service": "web-gw", "port": 8080}) is True
+
+        c.config.set(
+            "ingress-gateway",
+            "ingress-gateway-1",
+            {
+                "Listeners": [
+                    {
+                        "Port": 8080,
+                        "Protocol": "tcp",
+                        "Services": [{"Name": "web-gw"}],
+                    }
+                ]
+            },
+        )
+
+        time.sleep(0.5)
+
+        services = c.catalog.gateway_services("ingress-gateway-1")
+        assert [entry["Service"]["Name"] for entry in services] == ["web-gw"]
+        assert services[0]["GatewayKind"] == "ingress-gateway"
+
+        assert c.catalog.deregister("n-gw", service_id="ingress-gateway-1") is True
+        assert c.catalog.deregister("n-gw", service_id="web-gw") is True

--- a/tests/api/test_coordinates.py
+++ b/tests/api/test_coordinates.py
@@ -1,6 +1,42 @@
+import time
+
+
 class TestCoordinates:
     def test_coordinate(self, consul_obj) -> None:
         c, _consul_version = consul_obj
         c.coordinate.nodes()
         c.coordinate.datacenters()
         assert set(c.coordinate.datacenters()[0].keys()) == {"Datacenter", "Coordinates", "AreaID"}
+
+    def test_coordinate_update(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # find our own node name via the datacenters endpoint, which is
+        # populated as soon as the agent joins the WAN gossip pool
+        datacenters = c.coordinate.datacenters()
+        assert datacenters
+        node = datacenters[0]["Coordinates"][0]["Node"]
+
+        coord = {"Adjustment": 0, "Error": 1.5, "Height": 0, "Vec": [0, 0, 0, 0, 0, 0, 0, 0]}
+
+        # writing a coordinate update is somewhat artificial in a
+        # single-node dev-mode cluster (real updates normally come from the
+        # serf gossip / RTT estimation loop), but it lets us exercise the
+        # request/response contract of the endpoint.
+        assert c.coordinate.update(node, coord) is True
+
+        # coordinate.node/:node can 404 until the update has propagated
+        # through the catalog, so poll for a bit rather than sleeping a
+        # fixed, possibly-too-short amount of time.
+        result = None
+        for _ in range(20):
+            _index, result = c.coordinate.node(node)
+            if result:
+                break
+            time.sleep(0.5)
+
+        assert result is not None
+        entry = result[0]
+        assert entry["Node"] == node
+        assert entry["Coord"]["Error"] == coord["Error"]
+        assert entry["Coord"]["Vec"] == coord["Vec"]

--- a/tests/api/test_event.py
+++ b/tests/api/test_event.py
@@ -17,3 +17,38 @@ class TestEvent:
         _index, events = c.event.list(name="fooname")
         assert [x["Name"] == "fooname" for x in events]
         assert [x["Payload"] == "foobody" for x in events]
+
+    def test_event_fire_dc(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # the dev agent runs in dc1, so firing with the matching dc
+        # should behave exactly like not specifying it at all
+        assert c.event.fire("fooname", "foobody", dc="dc1")
+        _index, events = c.event.list(name="fooname")
+        assert [x["Name"] == "fooname" for x in events]
+        assert [x["Payload"] == "foobody" for x in events]
+
+    def test_event_list_node_service_tag_filters(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        node = c.agent.self()["Config"]["NodeName"]
+
+        assert c.event.fire("fooname", "foobody")
+
+        # node/service/tag are accepted as regex filter query params by the
+        # /v1/event/list endpoint (see
+        # https://developer.hashicorp.com/consul/api-docs/event). On a
+        # single dev-mode agent Consul does not actually exclude the event
+        # from the response based on these filters (they filter which
+        # agents *store* the event via gossip at fire time, not what a
+        # given agent returns from its local buffer), so we can only
+        # confirm here that passing them doesn't error and that matching
+        # events are still returned.
+        _index, events = c.event.list(name="fooname", node=node)
+        assert [x["Name"] == "fooname" for x in events]
+
+        _index, events = c.event.list(name="fooname", service="fooservice")
+        assert [x["Name"] == "fooname" for x in events]
+
+        _index, events = c.event.list(name="fooname", tag="footag")
+        assert [x["Name"] == "fooname" for x in events]

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -148,3 +148,140 @@ class TestHealth:
 
         _index, checks = c.health.checks("foobar")
         assert len(checks) == 0
+
+    def test_health_service_filter(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.agent.service.register("foo", service_id="foo:1", check=Check.ttl("10s"), tags=["tag:foo:1"])
+        c.agent.service.register("foo", service_id="foo:2", check=Check.ttl("10s"), tags=["tag:foo:2"])
+
+        time.sleep(0.2)
+
+        # filter_expr using bexpr syntax should behave like the (deprecated) tag param
+        _index, nodes = c.health.service("foo", filter_expr='"tag:foo:1" in Service.Tags')
+        assert [node["Service"]["ID"] for node in nodes] == ["foo:1"]
+
+        # a filter that matches nothing returns an empty list
+        _index, nodes = c.health.service("foo", filter_expr='"tag:does:not:exist" in Service.Tags')
+        assert nodes == []
+
+        c.agent.service.deregister("foo:1")
+        c.agent.service.deregister("foo:2")
+
+        time.sleep(0.2)
+
+    def test_health_service_merge_central_config(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.agent.service.register("foo", service_id="foo:1", check=Check.ttl("10s"))
+
+        time.sleep(0.2)
+
+        # merge_central_config shouldn't break the request or change the
+        # identity of the results, even with no central config entries set.
+        _index, nodes = c.health.service("foo", merge_central_config=True)
+        assert [node["Service"]["ID"] for node in nodes] == ["foo:1"]
+
+        c.agent.service.deregister("foo:1")
+
+        time.sleep(0.2)
+
+    def test_health_service_peer(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.agent.service.register("foo", service_id="foo:1", check=Check.ttl("10s"))
+
+        time.sleep(0.2)
+
+        # no peering is configured, so a peer name filters everything out
+        _index, nodes = c.health.service("foo", peer="non-existent-peer")
+        assert nodes == []
+
+        c.agent.service.deregister("foo:1")
+
+        time.sleep(0.2)
+
+    def test_health_connect(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        _index, nodes = c.health.connect("foo")
+        assert nodes == []
+
+        c.agent.service.register("foo", service_id="foo:1", check=Check.ttl("10s"))
+
+        time.sleep(0.2)
+
+        # "foo" itself isn't connect-capable, so it shouldn't show up here
+        _index, nodes = c.health.connect("foo")
+        assert nodes == []
+
+        c.agent.service.deregister("foo:1")
+
+        time.sleep(0.2)
+
+    def test_health_ingress(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.agent.service.register("foo", service_id="foo:1", check=Check.ttl("10s"))
+
+        time.sleep(0.2)
+
+        # no ingress gateway is configured to route to "foo"
+        _index, nodes = c.health.ingress("foo")
+        assert nodes == []
+
+        # filter_expr is supported and shouldn't error even when empty
+        _index, nodes = c.health.ingress("foo", filter_expr="Node.Node != `` ")
+        assert nodes == []
+
+        c.agent.service.deregister("foo:1")
+
+        time.sleep(0.2)
+
+    def test_health_state_filter(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.agent.service.register("foo", service_id="foo:1", check=Check.ttl("10s"))
+
+        time.sleep(0.2)
+
+        c.agent.check.ttl_pass("service:foo:1")
+
+        time.sleep(0.2)
+
+        _index, nodes = c.health.state("passing", filter_expr='ServiceID == "foo:1"')
+        assert [node["ServiceID"] for node in nodes] == ["foo:1"]
+
+        _index, nodes = c.health.state("passing", filter_expr='ServiceID == "does-not-exist"')
+        assert nodes == []
+
+        c.agent.service.deregister("foo:1")
+
+        time.sleep(0.2)
+
+    def test_health_checks_filter(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        c.agent.service.register("foobar", service_id="foobar", check=Check.ttl("10s"))
+
+        time.sleep(40 / 1000.00)
+
+        _index, checks = c.health.checks("foobar", filter_expr='CheckID == "service:foobar"')
+        assert [check["CheckID"] for check in checks] == ["service:foobar"]
+
+        _index, checks = c.health.checks("foobar", filter_expr='CheckID == "does-not-exist"')
+        assert checks == []
+
+        c.agent.service.deregister("foobar")
+
+        time.sleep(40 / 1000.0)
+
+    def test_health_node_filter(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+        node = c.agent.self()["Config"]["NodeName"]
+
+        _index, checks = c.health.node(node, filter_expr='Node == "does-not-exist"')
+        assert checks == []
+
+        _index, checks = c.health.node(node, filter_expr=f'Node == "{node}"')
+        assert node in [check["Node"] for check in checks]

--- a/tests/api/test_operator.py
+++ b/tests/api/test_operator.py
@@ -1,3 +1,10 @@
+import time
+
+import pytest
+
+import consul
+
+
 class TestOperator:
     def test_operator(self, consul_obj) -> None:
         c, _consul_version = consul_obj
@@ -13,3 +20,101 @@ class TestOperator:
                 voter = True
         assert leader
         assert voter
+
+    def test_raft_remove_peer_not_found(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # Removing a peer that isn't part of the Raft configuration is a
+        # server-side error (Consul returns a 500), not a boolean failure --
+        # verified against a live single-node dev cluster. We deliberately
+        # avoid removing the sole real peer here, since that would break the
+        # single-node cluster the rest of the tests run against.
+        with pytest.raises(consul.ConsulException):
+            c.operator.raft_remove_peer(address="10.255.255.1:8300")
+
+        with pytest.raises(consul.ConsulException):
+            c.operator.raft_remove_peer(peer_id="00000000-0000-0000-0000-000000000099")
+
+    def test_raft_transfer_leader_no_other_peers(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # On a single-node dev cluster there is no other peer to transfer
+        # leadership to, so Consul errors out instead of transferring.
+        with pytest.raises(consul.ConsulException):
+            c.operator.raft_transfer_leader()
+
+        with pytest.raises(consul.ConsulException):
+            c.operator.raft_transfer_leader(peer_id="00000000-0000-0000-0000-000000000099")
+
+    def test_autopilot_configuration(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        config = c.operator.autopilot_configuration()
+        assert config["CleanupDeadServers"] is True
+        assert "ModifyIndex" in config
+
+        # A cas that doesn't match the current ModifyIndex is a no-op that
+        # returns False rather than raising or applying the change.
+        assert (
+            c.operator.update_autopilot_configuration(cleanup_dead_servers=False, cas=config["ModifyIndex"] + 1000)
+            is False
+        )
+        assert c.operator.autopilot_configuration()["CleanupDeadServers"] is True
+
+        # Without cas (or with the correct cas) the update is unconditional.
+        assert c.operator.update_autopilot_configuration(cleanup_dead_servers=False) is True
+        updated = c.operator.autopilot_configuration()
+        assert updated["CleanupDeadServers"] is False
+
+        assert c.operator.update_autopilot_configuration(cleanup_dead_servers=True, cas=updated["ModifyIndex"]) is True
+        assert c.operator.autopilot_configuration()["CleanupDeadServers"] is True
+
+    def test_autopilot_health(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # A healthy single-node dev cluster returns HTTP 200 with Healthy=True;
+        # this must not raise even though the callback also has to handle the
+        # HTTP 429 "unhealthy" case without raising. Immediately after
+        # startup Consul can briefly report itself as unhealthy (HTTP 429)
+        # while the raft leader election settles -- verified live -- so
+        # retry a few times rather than asserting on the very first call.
+        health = c.operator.autopilot_health()
+        for _ in range(20):
+            if health["Healthy"]:
+                break
+            time.sleep(0.5)
+            health = c.operator.autopilot_health()
+
+        assert health["Healthy"] is True
+        assert len(health["Servers"]) == 1
+        assert health["Servers"][0]["Leader"] is True
+        assert health["Servers"][0]["Healthy"] is True
+
+    def test_keyring_without_encryption_errors(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        # The test fixtures start Consul without gossip encryption enabled,
+        # so the keyring is empty and every keyring operation is a real,
+        # observed server-side error (HTTP 500) rather than a boolean result.
+        with pytest.raises(consul.ConsulException):
+            c.operator.keyring_list()
+
+        with pytest.raises(consul.ConsulException):
+            c.operator.keyring_install(key="8CooQRX1+VK7MsQQK6lx2LhumpSfQzUjE63HdAu2hgA=")
+
+        with pytest.raises(consul.ConsulException):
+            c.operator.keyring_use(key="8CooQRX1+VK7MsQQK6lx2LhumpSfQzUjE63HdAu2hgA=")
+
+        with pytest.raises(consul.ConsulException):
+            c.operator.keyring_remove(key="8CooQRX1+VK7MsQQK6lx2LhumpSfQzUjE63HdAu2hgA=")
+
+    def test_usage(self, consul_obj) -> None:
+        c, _consul_version = consul_obj
+
+        usage = c.operator.usage()
+        assert "dc1" in usage["Usage"]
+        assert usage["Usage"]["dc1"]["Nodes"] >= 1
+        assert usage["KnownLeader"] is True
+
+        global_usage = c.operator.usage(global_=True, stale=True)
+        assert "dc1" in global_usage["Usage"]


### PR DESCRIPTION
## Summary

Phase 3 of the ongoing API-parity work (follow-up to #120/#121/#122) — closes out the remaining gaps tracked in `ENDPOINT_STATUS.md` for six existing endpoint groups, each as its own commit:

- **Agent** — `leave()`, `reload()`, `metrics()` (JSON + Prometheus), `monitor()` (single-shot, not true streaming — documented limitation), and a nested `Agent.Token` class for all five `PUT /v1/agent/token/:type` variants.
- **Operator** — raft peer removal/leader-transfer, autopilot config/health, keyring list/install/use/remove, usage. CE-only, per the earlier "no Enterprise" decision.
- **Catalog** — `filter`/`peer`/`merge-central-config` params, new `gateway_services()`, `SkipNodeUpdate`/`TaggedAddresses` on `register()`.
- **Health** — `filter`/`peer`/`merge-central-config` params, new `ingress()`.
- **Coordinate** — `node()` read, `update()` write.
- **Event** — `dc` on `fire()`, `node`/`service`/`tag` on `list()`.
- **Transport layer** — `HTTPClient.delete()` gained a `data` param (needed by `DELETE /v1/operator/keyring`, which requires a JSON body — every other write method already had this, delete() was the one gap).

## Bugs this surfaced (same pattern found twice)

`PUT /v1/operator/autopilot/configuration` with `cas` behaves exactly like `Config.set()`'s cas support from #121: always returns HTTP 200, with actual success/failure encoded as a JSON boolean **body**. Using status-only `CB.boolean()` there would have silently reported cas failures as successes — caught by a real integration test, fixed to use `CB.json()` matching the established `Config` precedent.

## Other real findings from live-probing (not just docs)

- `GET /v1/coordinate/node/:node` 404s in a fresh dev-mode Consul until a coordinate is actually written for that node — LAN coordinates aren't pre-populated by gossip the way `coordinate/datacenters` (WAN) is.
- `Event.list()`'s `node`/`service`/`tag` params are accepted without error but have no observable filtering effect at list-time in a single-node topology — they appear to only gate gossip propagation at fire-time. Tests assert the real behavior, not the docs' implication.
- `/catalog/services`' bexpr tag selector is `ServiceTags`, not `Tags`.
- `/catalog/node/:node`'s filter evaluates against each entry of the `Services` map, not the top-level document.
- `Health.ingress()` deliberately excludes `peer`/`merge-central-config` even though Consul doesn't error if you pass them — the canonical docs explicitly say ingress doesn't support them, so the client matches the documented contract over the lenient runtime behavior.

## Test plan

- [x] `mypy consul/ --no-sqlite-cache` — clean (32 source files)
- [x] `ruff check .` / `ruff format --diff .` — clean
- [x] New/extended integration tests across all six areas, run against real dockerized Consul (1.20.6/1.21.5/1.22.0) — 385 passing
- [x] Full existing test suite re-run — no regressions (only the 6 pre-existing failures in the untracked, unrelated `tests/test_features.py`)
- [x] `Agent.monitor()`'s test is intentionally scoped to the fast-fail path only (invalid loglevel → 400) — the success path is a genuinely unbounded blocking call with no per-request timeout anywhere in this library's transport layer, and there is no safe way to bound it from a test without either leaking a thread (Python's `concurrent.futures` atexit handler joins worker threads unconditionally, which would hang interpreter shutdown) or adding timeout support to `std.py`/`aio.py`, which is out of scope here.